### PR TITLE
Make the hiding of Print::write explicit

### DIFF
--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -106,6 +106,9 @@ class BootKeyboard_ : public Print, PluggableUSBModule {
 
     uint8_t* featureReport;
     int featureLength;
+
+  private:
+    using Print::write;
 };
 extern BootKeyboard_ BootKeyboard;
 

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -64,6 +64,8 @@ class Keyboard_ : public Print {
   protected:
     HID_KeyboardReport_Data_t _keyReport;
 
+  private:
+    using Print::write;
 };
 extern Keyboard_ Keyboard;
 


### PR DESCRIPTION
To avoid a compiler warning (with `-Woverloaded-virtual`), mark `Print::write` as private in both `BootKeyboard.h` and `MultiReport/Keyboard.h`.

The original `Print::write` is not used anywhere, the intent is clearly to hide it. Let the compiler know that, too.
