### PR TITLE
Add a method to return if a modifier is active

### DIFF
--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -129,6 +129,14 @@ int Keyboard_::sendReport(void) {
     return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &_keyReport, sizeof(_keyReport));
 }
 
+boolean Keyboard_::isModifierActive(uint8_t k) {
+  if(k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    return !!(_keyReport.modifiers & (1 << k));
+  }
+  return false;
+}
+
 size_t Keyboard_::press(uint8_t k) {
     // If the key is in the range of 'printable' keys 
     if (k <= HID_KEYPAD_HEXADECIMAL ) {

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -61,6 +61,8 @@ class Keyboard_ : public Print {
     int sendReport(void);
     size_t write(uint8_t k);
 
+    boolean isModifierActive(uint8_t k);
+
   protected:
     HID_KeyboardReport_Data_t _keyReport;
 


### PR DESCRIPTION
In case one would like to implement behaviour that changes when a modifier is active, one would need to know the state of the modifier. While it is possible to track this on a higher level, this is something already available in the report. As such, the most straightforward way to achieve this goal is to have a function that looks into the report.

This patch does just that.
