### PR TITLE
Remove all 'flexible arrays', which is not a valid C++ construct

### DIFF
--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -34,9 +34,6 @@ THE SOFTWARE.
 
 typedef union {
     // Low level key report: up to 6 keys and shift, ctrl etc at once
-    uint8_t whole8[];
-    uint16_t whole16[];
-    uint32_t whole32[];
     struct {
         uint8_t modifiers;
         uint8_t reserved;

--- a/src/MultiReport/AbsoluteMouse.h
+++ b/src/MultiReport/AbsoluteMouse.h
@@ -42,9 +42,6 @@ THE SOFTWARE.
 
 typedef union {
     // Absolute mouse report: 8 buttons, 2 absolute axis, wheel
-    uint8_t whole8[];
-    uint16_t whole16[];
-    uint32_t whole32[];
     struct {
         uint8_t buttons;
         uint16_t xAxis;

--- a/src/MultiReport/ConsumerControl.h
+++ b/src/MultiReport/ConsumerControl.h
@@ -31,9 +31,6 @@ THE SOFTWARE.
 
 typedef union {
     // Every usable Consumer key possible, up to 4 keys presses possible
-    uint8_t whole8[];
-    uint16_t whole16[];
-    uint32_t whole32[];
     uint16_t keys[4];
     struct {
         uint16_t key1;

--- a/src/MultiReport/Gamepad.h
+++ b/src/MultiReport/Gamepad.h
@@ -43,9 +43,6 @@ THE SOFTWARE.
 
 typedef union {
     // 32 Buttons, 6 Axis, 2 D-Pads
-    uint8_t whole8[];
-    uint16_t whole16[];
-    uint32_t whole32[];
     uint32_t buttons;
 
     struct {

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -37,9 +37,6 @@ THE SOFTWARE.
 
 typedef union {
     // Modifiers + keymap 
-    uint8_t whole8[];
-    uint16_t whole16[];
-    uint32_t whole32[];
     struct {
         uint8_t modifiers;
         uint8_t keys[KEY_BYTES ];

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -40,9 +40,6 @@ THE SOFTWARE.
 
 typedef union {
     // Mouse report: 8 buttons, position, wheel
-    uint8_t whole8[];
-    uint16_t whole16[];
-    uint32_t whole32[];
     struct {
         uint8_t buttons;
         int8_t xAxis;

--- a/src/MultiReport/SystemControl.h
+++ b/src/MultiReport/SystemControl.h
@@ -32,7 +32,6 @@ THE SOFTWARE.
 
 typedef union {
     // Every usable system control key possible
-    uint8_t whole8[];
     uint8_t key;
 } HID_SystemControlReport_Data_t;
 


### PR DESCRIPTION
Flexible arrays is not a C++ feature. It appears that in GCC 4.x they are allowed, but when compiling this code with GCC 6.x a flexible array declaration will produce an error.

I have not delved deeply into this code, but it appears to me that the whole8, whole16 and whole32 members inside the unions are meant to provide an "alternate" view into the unions, that are just arrays. But since these are never used it should be safe to remove them.

I may be completely wrong about all this. If so, just ignore my pull request.