### PR TITLE
ConsumerControl: Report separately from press / release

### DIFF
--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -69,7 +69,6 @@ void ConsumerControl_::press(uint16_t m) {
       break;
     }
   }
-  sendReport(&_report, sizeof(_report));
 }
 
 void ConsumerControl_::release(uint16_t m) {
@@ -80,15 +79,18 @@ void ConsumerControl_::release(uint16_t m) {
       // no break to delete multiple keys
     }
   }
-  sendReport(&_report, sizeof(_report));
 }
 
 void ConsumerControl_::releaseAll(void) {
-  end();
+  memset(&_report, 0, sizeof(_report));
 }
 
 void ConsumerControl_::sendReport(void* data, int length) {
   HID().SendReport(HID_REPORTID_CONSUMERCONTROL, data, length);
+}
+
+void ConsumerControl_::sendReport(void) {
+  sendReport(&_report, sizeof(_report));
 }
 
 ConsumerControl_ ConsumerControl;

--- a/src/MultiReport/ConsumerControl.h
+++ b/src/MultiReport/ConsumerControl.h
@@ -53,7 +53,7 @@ class ConsumerControl_ {
 
   // Sending is public in the base class for advanced users.
   void sendReport(void* data, int length);
-
+  void sendReport(void);
 
  protected:
   HID_ConsumerControlReport_Data_t _report;

--- a/src/MultiReport/ConsumerControl.h
+++ b/src/MultiReport/ConsumerControl.h
@@ -52,10 +52,13 @@ class ConsumerControl_ {
   void releaseAll(void);
 
   // Sending is public in the base class for advanced users.
-  void sendReport(void* data, int length);
   void sendReport(void);
 
  protected:
   HID_ConsumerControlReport_Data_t _report;
+  HID_ConsumerControlReport_Data_t _lastReport;
+
+ private:
+  void sendReportUnchecked(void);
 };
 extern ConsumerControl_ ConsumerControl;


### PR DESCRIPTION
Instead of always sending a report on every `press`, `release`, and `releaseAll`, let the user of this code decide when to send the report. This will allow us to treat `ConsumerControl` the same way we do with `Keyboard`, and clear the report each cycle. That in turn will help us not send many presses for the same key in a single report.

This is one half of the change that is needed to address keyboardio/Kaleidoscope#176.