### PR TITLE
Mouse: Pull sendReport out of move & buttons

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -75,51 +75,47 @@ void Mouse_::begin(void) {
 }
 
 void Mouse_::end(void) {
-  _buttons = 0;
-  move(0, 0, 0);
+  releaseAll();
+  sendReport();
 }
 
 void Mouse_::click(uint8_t b) {
-  _buttons = b;
-  move(0,0,0);
-  _buttons = 0;
-  move(0,0,0);
+  press(b);
+  sendReport();
+  release(b);
 }
 
 void Mouse_::move(signed char x, signed char y, signed char vWheel, signed char hWheel) {
-  HID_MouseReport_Data_t report;
-  report.buttons = _buttons;
   report.xAxis = x;
   report.yAxis = y;
   report.vWheel = vWheel;
   report.hWheel = hWheel;
-  sendReport(&report, sizeof(report));
 }
 
-void Mouse_::buttons(uint8_t b) {
-  if (b != _buttons) {
-    _buttons = b;
-    move(0,0,0);
-  }
+void Mouse_::releaseAll(void) {
+  memset(&report, 0, sizeof(report));
 }
 
 void Mouse_::press(uint8_t b) {
-  buttons(_buttons | b);
+  report.buttons |= b;
 }
 
 void Mouse_::release(uint8_t b) {
-  buttons(_buttons & ~b);
+  report.buttons &= ~b;
 }
 
 bool Mouse_::isPressed(uint8_t b) {
-  if ((b & _buttons) > 0)
+  if ((b & report.buttons) > 0)
     return true;
   return false;
 }
 
-
 void Mouse_::sendReport(void* data, int length) {
   HID().SendReport(HID_REPORTID_MOUSE, data, length);
+}
+
+void Mouse_::sendReport(void) {
+  sendReport(&report, sizeof(report));
 }
 
 Mouse_ Mouse;

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -119,9 +119,16 @@ void Mouse_::sendReport(void) {
   // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
   // if sendReport is called in a tight loop.
 
-  // if the two reports are the same, return early without a report
-  if (memcmp(&lastReport, &report, sizeof(report)) == 0)
-    return;
+  // if the two reports are the same, check if they're empty, and return early
+  // without a report if they are.
+  if (memcmp(&lastReport, &report, sizeof(report)) == 0) {
+    if (0 == report.buttons &&
+        0 == report.xAxis &&
+        0 == report.yAxis &&
+        0 == report.vWheel &&
+        0 == report.hWheel)
+      return;
+  }
 
   sendReportUnchecked();
   memcpy(&lastReport, &report, sizeof(report));

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -110,12 +110,21 @@ bool Mouse_::isPressed(uint8_t b) {
   return false;
 }
 
-void Mouse_::sendReport(void* data, int length) {
-  HID().SendReport(HID_REPORTID_MOUSE, data, length);
+void Mouse_::sendReportUnchecked(void) {
+  HID().SendReport(HID_REPORTID_MOUSE, &report, sizeof(report));
 }
 
 void Mouse_::sendReport(void) {
-  sendReport(&report, sizeof(report));
+  // If the last report is different than the current report, then we need to send a report.
+  // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
+  // if sendReport is called in a tight loop.
+
+  // if the two reports are the same, return early without a report
+  if (memcmp(&lastReport, &report, sizeof(report)) == 0)
+    return;
+
+  sendReportUnchecked();
+  memcpy(&lastReport, &report, sizeof(report));
 }
 
 Mouse_ Mouse;

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -121,14 +121,10 @@ void Mouse_::sendReport(void) {
 
   // if the two reports are the same, check if they're empty, and return early
   // without a report if they are.
-  if (memcmp(&lastReport, &report, sizeof(report)) == 0) {
-    if (0 == report.buttons &&
-        0 == report.xAxis &&
-        0 == report.yAxis &&
-        0 == report.vWheel &&
-        0 == report.hWheel)
-      return;
-  }
+  static HID_MouseReport_Data_t emptyReport;
+  if (memcmp(&lastReport, &report, sizeof(report)) == 0 &&
+      memcmp(&report, &emptyReport, sizeof(report)) == 0)
+    return;
 
   sendReportUnchecked();
   memcpy(&lastReport, &report, sizeof(report));

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -53,12 +53,15 @@ class Mouse_ {
   void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
   bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default
 
-  void sendReport(void* data, int length);
   void sendReport(void);
 
   void releaseAll(void);
 
  protected:
   HID_MouseReport_Data_t report;
+  HID_MouseReport_Data_t lastReport;
+
+ private:
+  void sendReportUnchecked(void);
 };
 extern Mouse_ Mouse;

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -54,9 +54,11 @@ class Mouse_ {
   bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default
 
   void sendReport(void* data, int length);
+  void sendReport(void);
+
+  void releaseAll(void);
 
  protected:
-  uint8_t _buttons;
-  void buttons(uint8_t b);
+  HID_MouseReport_Data_t report;
 };
 extern Mouse_ Mouse;


### PR DESCRIPTION
Instead of sending a report immediately after a move or a button press, let the user of the library decide when to send it. While there, also expose a `releaseAll` method, so we follow the same pattern as `Keyboard`, allowing the user to send & clear the report each cycle.

This separation is required to address keyboardio/Kaleidoscope-MouseKeys#10.