### PR TITLE
AbsMouse: Remove support for the horizontal scroll wheel

### DIFF
--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -63,24 +63,13 @@ THE SOFTWARE.
   D_REPORT_COUNT, 0x01,                     /*     REPORT_COUNT (1) */		\
   D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),
 
-#define DESCRIPTOR_ABS_MOUSE_HWHEEL \
-  D_USAGE_PAGE, D_PAGE_CONSUMER, /* USAGE_PAGE (Consumer Device) */ \
-  D_PAGE_ORDINAL, 0x38, 0x02, \
-  D_USAGE_MINIMUM, 0x81, \
-  D_USAGE_MAXIMUM, 0x7f, \
-  D_REPORT_SIZE, 0x08, \
-  D_REPORT_COUNT, 0x01, \
-  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE), 
- 
-
 typedef union {
     // Absolute mouse report: 8 buttons, 2 absolute axis, wheel
     struct {
         uint8_t buttons;
         uint16_t xAxis;
         uint16_t yAxis;
-        int8_t vWheel;
-        int8_t hWheel;
+        int8_t wheel;
     };
 } HID_MouseAbsoluteReport_Data_t;
 
@@ -91,8 +80,8 @@ class AbsoluteMouseAPI {
     inline void end(void);
 
     inline void click(uint8_t b = MOUSE_LEFT);
-    inline void moveTo(uint16_t x, uint16_t y, signed char vWheel = 0, signed char hWheel = 0);
-    inline void move(int x, int y, signed char vWheel = 0, signed char hWheel = 0);
+    inline void moveTo(uint16_t x, uint16_t y, signed char wheel = 0);
+    inline void move(int x, int y, signed char wheel = 0);
     inline void press(uint8_t b = MOUSE_LEFT);
     inline void release(uint8_t b = MOUSE_LEFT);
     inline bool isPressed(uint8_t b = MOUSE_LEFT);
@@ -110,4 +99,3 @@ class AbsoluteMouseAPI {
 };
 
 #include "AbsoluteMouseAPI.hpp"
-

--- a/src/DeviceAPIs/AbsoluteMouseAPI.hpp
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.hpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #pragma once
 
-AbsoluteMouseAPI::AbsoluteMouseAPI(void): xAxis(0), yAxis(0), _buttons(0) { // Empty 
+AbsoluteMouseAPI::AbsoluteMouseAPI(void): xAxis(0), yAxis(0), _buttons(0) { // Empty
 }
 
 void AbsoluteMouseAPI::buttons(uint8_t b) {
@@ -68,20 +68,19 @@ void AbsoluteMouseAPI::click(uint8_t b) {
   moveTo(xAxis, yAxis, 0);
 }
 
-void AbsoluteMouseAPI::moveTo(uint16_t x, uint16_t y, signed char vWheel, signed char hWheel) {
+void AbsoluteMouseAPI::moveTo(uint16_t x, uint16_t y, signed char wheel) {
   xAxis = x;
   yAxis = y;
   HID_MouseAbsoluteReport_Data_t report;
   report.buttons = _buttons;
   report.xAxis = x;
   report.yAxis = y;
-  report.vWheel = vWheel;
-  report.hWheel = hWheel;
+  report.wheel = wheel;
   sendReport(&report, sizeof(report));
 }
 
-void AbsoluteMouseAPI::move(int x, int y, signed char vWheel, signed char hWheel) {
-  moveTo(qadd16(xAxis, x), qadd16(yAxis, y), vWheel, hWheel);
+void AbsoluteMouseAPI::move(int x, int y, signed char wheel) {
+  moveTo(qadd16(xAxis, x), qadd16(yAxis, y), wheel);
 }
 
 void AbsoluteMouseAPI::press(uint8_t b) {

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -34,7 +34,6 @@ static const uint8_t _hidMultiReportDescriptorAbsoluteMouse[] PROGMEM = {
     DESCRIPTOR_ABS_MOUSE_BUTTONS
     DESCRIPTOR_ABS_MOUSE_XY
     DESCRIPTOR_ABS_MOUSE_WHEEL
-    DESCRIPTOR_ABS_MOUSE_HWHEEL
 
     D_END_COLLECTION 				 /* End */
 };


### PR DESCRIPTION
We do not use the wheels on `AbsoluteMouse`, and having the horizontal wheel added to the descriptor causes issues at least on Linux, rendering the whole of `AbsoluteMouse` unusable. With the horizontal wheel support gone, it works again.

Fixes #15.
