### PR TITLE
Support a fallback to boot report protocol

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -196,6 +196,10 @@ uint8_t BootKeyboard_::getProtocol(void) {
   return protocol;
 }
 
+void BootKeyboard_::setProtocol(uint8_t protocol) {
+  this->protocol = protocol;
+}
+
 int BootKeyboard_::sendReport(void) {
   if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
     // if the two reports are different, send a report

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -92,7 +92,7 @@ int BootKeyboard_::getDescriptor(USBSetup& setup) {
 
   // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
   // due to the USB specs, but Windows and Linux just assumes its in report mode.
-  protocol = HID_REPORT_PROTOCOL;
+  protocol = default_protocol;
 
   return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorKeyboard, sizeof(_hidReportDescriptorKeyboard));
 }

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -39,17 +39,6 @@ static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
   0x95, 0x08,                      /*   REPORT_COUNT (8) */
   0x81, 0x02,                      /*   INPUT (Data,Var,Abs) */
 
-  /* Reserved byte, used for consumer reports, only works with linux */
-  /* NOT CURRENTLY USED BY THIS IMPLEMENTATION */
-  0x05, 0x0C,             		 /*   Usage Page (Consumer) */
-  0x95, 0x01,                      /*   REPORT_COUNT (1) */
-  0x75, 0x08,                      /*   REPORT_SIZE (8) */
-  0x15, 0x00,                      /*   LOGICAL_MINIMUM (0) */
-  0x26, 0xFF, 0x00,                /*   LOGICAL_MAXIMUM (255) */
-  0x19, 0x00,                      /*   USAGE_MINIMUM (0) */
-  0x29, 0xFF,                      /*   USAGE_MAXIMUM (255) */
-  0x81, 0x00,                      /*   INPUT (Data,Ary,Abs) */
-
   /* 5 LEDs for num lock etc, 3 left for advanced, custom usage */
   0x05, 0x08,						 /*   USAGE_PAGE (LEDs) */
   0x19, 0x01,						 /*   USAGE_MINIMUM (Num Lock) */

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -53,7 +53,8 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   int sendReport(void);
 
-
+  boolean isModifierActive(uint8_t k);
+  boolean wasModifierActive(uint8_t k);
 
   uint8_t getLeds(void);
   uint8_t getProtocol(void);
@@ -86,7 +87,7 @@ class BootKeyboard_ : public PluggableUSBModule {
 
 
  protected:
-  HID_BootKeyboardReport_Data_t _keyReport;
+  HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;
 
   // Implementation of the PUSBListNode
   int getInterface(uint8_t* interfaceCount);

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -35,10 +35,9 @@ typedef union {
   // Low level key report: up to 6 keys and shift, ctrl etc at once
   struct {
     uint8_t modifiers;
-    uint8_t reserved;
     uint8_t keycodes[6];
   };
-  uint8_t keys[8];
+  uint8_t keys[7];
 } HID_BootKeyboardReport_Data_t;
 
 

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -84,6 +84,7 @@ class BootKeyboard_ : public PluggableUSBModule, public BootKeyboardAPI {
     featureLength |= 0x8000;
   }
 
+  uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
  protected:
   HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "HID-Settings.h"
 #include "HIDTables.h"
 #include "HIDAliases.h"
+#include "BootKeyboard/BootKeyboardAPI.h"
 
 typedef union {
   // Low level key report: up to 6 keys and shift, ctrl etc at once
@@ -40,8 +41,7 @@ typedef union {
   uint8_t keys[7];
 } HID_BootKeyboardReport_Data_t;
 
-
-class BootKeyboard_ : public PluggableUSBModule {
+class BootKeyboard_ : public PluggableUSBModule, public BootKeyboardAPI {
  public:
   BootKeyboard_(void);
   size_t press(uint8_t);

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -57,6 +57,7 @@ class BootKeyboard_ : public PluggableUSBModule, public BootKeyboardAPI {
 
   uint8_t getLeds(void);
   uint8_t getProtocol(void);
+  void setProtocol(uint8_t protocol);
   void wakeupHost(void);
 
   void setFeatureReport(void* report, int length) {

--- a/src/BootKeyboard/BootKeyboardAPI.h
+++ b/src/BootKeyboard/BootKeyboardAPI.h
@@ -9,6 +9,7 @@ class BootKeyboardAPI {
   virtual void releaseAll(void) = 0;
   virtual int sendReport(void) = 0;
   virtual uint8_t getProtocol(void) = 0;
+  virtual void setProtocol(uint8_t protocol) = 0;
   virtual boolean isModifierActive(uint8_t k) = 0;
   virtual boolean wasModifierActive(uint8_t k) = 0;
 };

--- a/src/BootKeyboard/BootKeyboardAPI.h
+++ b/src/BootKeyboard/BootKeyboardAPI.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class BootKeyboardAPI {
+ public:
+  virtual size_t press(uint8_t) = 0;
+  virtual void begin(void) = 0;
+  virtual void end(void) = 0;
+  virtual size_t release(uint8_t) = 0;
+  virtual void releaseAll(void) = 0;
+  virtual int sendReport(void) = 0;
+  virtual uint8_t getProtocol(void) = 0;
+  virtual boolean isModifierActive(uint8_t k) = 0;
+  virtual boolean wasModifierActive(uint8_t k) = 0;
+};

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -125,20 +125,29 @@ void Keyboard_::begin(void) {
   // while the sender is resetted.
   releaseAll();
   sendReportUnchecked();
+
+  if (bootKeyboard)
+    bootKeyboard->begin();
 }
 
 
 void Keyboard_::end(void) {
   releaseAll();
   sendReportUnchecked();
+
+  if (bootKeyboard)
+    bootKeyboard->end();
 }
 
 int Keyboard_::sendReportUnchecked(void) {
     return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));
 }
 
-
 int Keyboard_::sendReport(void) {
+  if (bootKeyboard && bootKeyboard->getProtocol() == HID_BOOT_PROTOCOL ) {
+    return bootKeyboard->sendReport();
+  }
+
   // If the last report is different than the current report, then we need to send a report.
   // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
   // if sendReport is called in a tight loop.
@@ -156,6 +165,10 @@ int Keyboard_::sendReport(void) {
  * Returns false in all other cases
  * */
 boolean Keyboard_::isModifierActive(uint8_t k) {
+  if (bootKeyboard && bootKeyboard->getProtocol() == HID_BOOT_PROTOCOL) {
+    return bootKeyboard->isModifierActive(k);
+  }
+
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
     return !!(keyReport.modifiers & (1 << k));
@@ -167,6 +180,10 @@ boolean Keyboard_::isModifierActive(uint8_t k) {
  * Returns false in all other cases
  * */
 boolean Keyboard_::wasModifierActive(uint8_t k) {
+  if (bootKeyboard && bootKeyboard->getProtocol() == HID_BOOT_PROTOCOL) {
+    return bootKeyboard->wasModifierActive(k);
+  }
+
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
     return !!(lastKeyReport.modifiers & (1 << k));
@@ -175,6 +192,10 @@ boolean Keyboard_::wasModifierActive(uint8_t k) {
 }
 
 size_t Keyboard_::press(uint8_t k) {
+  if (bootKeyboard && bootKeyboard->getProtocol() == HID_BOOT_PROTOCOL) {
+    return bootKeyboard->press(k);
+  }
+
   // If the key is in the range of 'printable' keys
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (uint8_t(k) % 8);
@@ -195,6 +216,10 @@ size_t Keyboard_::press(uint8_t k) {
 }
 
 size_t Keyboard_::release(uint8_t k) {
+  if (bootKeyboard && bootKeyboard->getProtocol() == HID_BOOT_PROTOCOL) {
+    return bootKeyboard->release(k);
+  }
+
   // If we're releasing a printable key
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (k % 8);
@@ -215,6 +240,10 @@ size_t Keyboard_::release(uint8_t k) {
 }
 
 void Keyboard_::releaseAll(void) {
+  if (bootKeyboard && bootKeyboard->getProtocol() == HID_BOOT_PROTOCOL ) {
+    return bootKeyboard->releaseAll();
+  }
+
   // Release all keys
   memset(&keyReport.allkeys, 0x00, sizeof(keyReport.allkeys));
 }

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -32,6 +32,8 @@ THE SOFTWARE.
 #include "HIDTables.h"
 #include "HIDAliases.h"
 
+#include "BootKeyboard/BootKeyboardAPI.h"
+
 #define KEY_BYTES 28
 
 typedef union {
@@ -63,6 +65,8 @@ class Keyboard_ {
 
   HID_KeyboardReport_Data_t keyReport;
   HID_KeyboardReport_Data_t lastKeyReport;
+
+  BootKeyboardAPI *bootKeyboard = NULL;
  private:
   int sendReportUnchecked(void);
 };


### PR DESCRIPTION
Based on earlier work by @obra, this first refactors `BootKeyboard` a little, preparing it to be used as a fallback, then adds a bit of logic to `Keyboard` that dispatches everything to `BootKeyboard` if we are in boot mode. By default, we rely on the host to send a `SET_PROTOCOL` request to put us into boot mode, while defaulting to report mode. The default can be changed by setting `BootKeyboard.default_protocol` to `HID_BOOT_PROTOCOL`. If a manual override is required, `BootKeyboard.setProtocol` can do that.

Boot mode is optional, and disabled by default. Another PR against `Kaleidoscope` will add a small macro that makes it easier to enable it.

While this works on FreeBSD (which does not support NKRO), I have not tested it anywhere else.

Fixes #10.