### PR TITLE
Mouse: Append the descriptor late, in Mouse.begin

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -95,11 +95,12 @@ static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
 };
 
 Mouse_::Mouse_(void) {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));
-  HID().AppendDescriptor(&node);
 }
 
 void Mouse_::begin(void) {
+  static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));
+  HID().AppendDescriptor(&node);
+
   end();
 }
 


### PR DESCRIPTION
Because `Mouse` is *always* instantiated, the constructor always runs, and thus, the node is always registered whenever the `Mouse` object is referenced, even if done so in code that gets optimized out. To combat this, and allow the compiler to optimize out `Mouse` fully, do the append in `Mouse.begin`. This way, if the `Mouse` global is referenced by code that gets optimized out, the constructor will be optimized out, allowing the full object to get dropped. As we call `Mouse.begin` during `setup`, there is no risk doing a late append, either.

This addresses the most important part of keyboardio/Kaleidoscope#257.
