### PR TITLE
Revert the Mouse USB HID descriptor change, and fix hWheel better

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -26,44 +26,43 @@ THE SOFTWARE.
 
 static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
   /*  Mouse relative */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,                      /* USAGE_PAGE (Generic Desktop)	  54 */
-  D_USAGE, D_USAGE_MOUSE,                      /* USAGE (Mouse) */
-  D_COLLECTION, D_APPLICATION,                      /* COLLECTION (Application) */
-  D_REPORT_ID, HID_REPORTID_MOUSE,				/*     REPORT_ID */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
+  D_USAGE, D_USAGE_MOUSE,                         //  USAGE (Mouse)
+  D_COLLECTION, D_APPLICATION,                    //   COLLECTION (Application)
+  D_REPORT_ID, HID_REPORTID_MOUSE,                //    REPORT_ID (Mouse)
 
   /* 8 Buttons */
-  D_USAGE_PAGE, D_PAGE_BUTTON,                      /*     USAGE_PAGE (Button) */
-  D_USAGE_MINIMUM, 0x01,                      /*     USAGE_MINIMUM (Button 1) */
-  D_USAGE_MAXIMUM, 0x08,                      /*     USAGE_MAXIMUM (Button 8) */
-  D_LOGICAL_MINIMUM, 0x00,                      /*     LOGICAL_MINIMUM (0) */
-  D_LOGICAL_MAXIMUM, 0x01,                      /*     LOGICAL_MAXIMUM (1) */
-  D_REPORT_COUNT, 0x08,                      /*     REPORT_COUNT (8) */
-  D_REPORT_SIZE, 0x01,                      /*     REPORT_SIZE (1) */
-  D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),                      /*     INPUT (Data,Var,Abs) */
+  D_USAGE_PAGE, D_PAGE_BUTTON,                    //    USAGE_PAGE (Button)
+  D_USAGE_MINIMUM, 0x01,                          //     USAGE_MINIMUM (Button 1)
+  D_USAGE_MAXIMUM, 0x08,                          //     USAGE_MAXIMUM (Button 8)
+  D_LOGICAL_MINIMUM, 0x00,                        //     LOGICAL_MINIMUM (0)
+  D_LOGICAL_MAXIMUM, 0x01,                        //     LOGICAL_MAXIMUM (1)
+  D_REPORT_COUNT, 0x08,                           //     REPORT_COUNT (8)
+  D_REPORT_SIZE, 0x01,                            //     REPORT_SIZE (1)
+  D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),        //     INPUT (Data,Var,Abs)
 
   /* X, Y, Wheel */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,                      /*     USAGE_PAGE (Generic Desktop) */
-  D_USAGE, 0x30,                      /*     USAGE (X) */
-  D_USAGE, 0x31,                      /*     USAGE (Y) */
-  D_USAGE, 0x38,                      /*     USAGE (Wheel) */
-  D_LOGICAL_MINIMUM, 0x81,                      /*     LOGICAL_MINIMUM (-127) */
-  D_LOGICAL_MAXIMUM, 0x7f,                      /*     LOGICAL_MAXIMUM (127) */
-  D_REPORT_SIZE, 0x08,                      /*     REPORT_SIZE (8) */
-  D_REPORT_COUNT, 0x03,                      /*     REPORT_COUNT (3) */
-  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE), /*     INPUT (Data,Var,Rel) */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           //    USAGE_PAGE (Generic Desktop)
+  D_USAGE, 0x30,                                  //     USAGE (X)
+  D_USAGE, 0x31,                                  //     USAGE (Y)
+  D_USAGE, 0x38,                                  //     USAGE (Wheel)
+  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x03,                           //     REPORT_COUNT (3)
+  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
 
   /* Horizontal wheel */
-  D_USAGE_PAGE, D_PAGE_CONSUMER, /* USAGE_PAGE (Consumer Device) */
-  D_PAGE_ORDINAL, 0x38, 0x02,
-  D_LOGICAL_MINIMUM, 0x81,
-  D_LOGICAL_MAXIMUM, 0x7f,
-  D_REPORT_SIZE, 0x08,
-  D_REPORT_COUNT, 0x01,
-  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),
-  /* End */
-  D_END_COLLECTION                            /* END_COLLECTION */
-};
+  D_USAGE_PAGE, D_PAGE_CONSUMER,                  //    USAGE_PAGE (Consumer)
+  D_PAGE_ORDINAL, 0x38, 0x02,                     //     PAGE (AC Pan)
+  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
+  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
 
+  /* End */
+  D_END_COLLECTION                                // END_COLLECTION
+};
 
 Mouse_::Mouse_(void) {
   static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -26,73 +26,44 @@ THE SOFTWARE.
 
 static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
   /*  Mouse relative */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
-  D_USAGE, D_USAGE_MOUSE,                         //  USAGE (Mouse)
-  D_COLLECTION, D_APPLICATION,                    //   COLLECTION (Application)
-  D_REPORT_ID, HID_REPORTID_MOUSE,				        //    REPORT_ID (Mouse)
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,                      /* USAGE_PAGE (Generic Desktop)	  54 */
+  D_USAGE, D_USAGE_MOUSE,                      /* USAGE (Mouse) */
+  D_COLLECTION, D_APPLICATION,                      /* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_MOUSE,				/*     REPORT_ID */
 
   /* 8 Buttons */
-  D_USAGE_PAGE, D_PAGE_BUTTON,                    //    USAGE_PAGE (Button)
-  D_USAGE_MINIMUM, 0x01,                          //     USAGE_MINIMUM (Button 1)
-  D_USAGE_MAXIMUM, 0x08,                          //     USAGE_MAXIMUM (Button 8)
-  D_LOGICAL_MINIMUM, 0x00,                        //     LOGICAL_MINIMUM (0)
-  D_LOGICAL_MAXIMUM, 0x01,                        //     LOGICAL_MAXIMUM (1)
-  D_REPORT_COUNT, 0x08,                           //     REPORT_COUNT (8)
-  D_REPORT_SIZE, 0x01,                            //     REPORT_SIZE (1)
-  D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),        //     INPUT (Data,Var,Abs)
+  D_USAGE_PAGE, D_PAGE_BUTTON,                      /*     USAGE_PAGE (Button) */
+  D_USAGE_MINIMUM, 0x01,                      /*     USAGE_MINIMUM (Button 1) */
+  D_USAGE_MAXIMUM, 0x08,                      /*     USAGE_MAXIMUM (Button 8) */
+  D_LOGICAL_MINIMUM, 0x00,                      /*     LOGICAL_MINIMUM (0) */
+  D_LOGICAL_MAXIMUM, 0x01,                      /*     LOGICAL_MAXIMUM (1) */
+  D_REPORT_COUNT, 0x08,                      /*     REPORT_COUNT (8) */
+  D_REPORT_SIZE, 0x01,                      /*     REPORT_SIZE (1) */
+  D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),                      /*     INPUT (Data,Var,Abs) */
 
-  /* X, Y */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           //    USAGE_PAGE (Generic Desktop)
-  D_USAGE, 0x30,                                  //     USAGE (X)
-  D_USAGE, 0x31,                                  //     USAGE (Y)
-  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
-  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
-  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
-  D_REPORT_COUNT, 0x02,                           //     REPORT_COUNT (3)
-  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
-
-  /* Wheels */
-
-  /* Vertical wheel */
-  D_COLLECTION, D_LOGICAL,                        //     COLLECTION (Logical)
-  D_USAGE, 0x48,                                  //      USAGE (Resolution Multiplier)
-  D_LOGICAL_MINIMUM, 0x00,                        //       LOGICAL_MINIMUM (0)
-  D_LOGICAL_MAXIMUM, 0x01,                        //       LOGICAL_MAXIMUM (1)
-  D_PHYSICAL_MINIMUM, 0x01,                       //       PHYSICAL_MINIMUM (1)
-  D_PHYSICAL_MAXIMUM, 0x04,                       //       PHYSICAL_MAXIMUM (4)
-  D_REPORT_SIZE, 0x02,                            //       REPORT_SIZE (2)
-  D_REPORT_COUNT, 0x01,                           //       REPORT_COUNT (1)
-  D_PUSH,                                         //       PUSH
-  D_FEATURE, (D_DATA|D_VARIABLE|D_ABSOLUTE),      //       FEATURE (Data,Var,Abs)
-  D_USAGE, 0x38,                                  //      USAGE (Wheel)
-  D_LOGICAL_MINIMUM, 0x81,                        //       LOGICAL_MINIMUM (-127)
-  D_LOGICAL_MAXIMUM, 0x7f,                        //       LOGICAL_MAXIMUM (127)
-  D_PHYSICAL_MINIMUM, 0x00,                       //       PHYSICAL_MINIMUM (0)
-  D_PHYSICAL_MAXIMUM, 0x00,                       //       PHYSICAL_MAXIMUM (0)
-  D_REPORT_SIZE, 0x08,                            //       REPORT_SIZE (8)
-  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //       INPUT (Data,Var,Rel)
-  D_END_COLLECTION,                               //     END_COLLECTION
+  /* X, Y, Wheel */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,                      /*     USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x30,                      /*     USAGE (X) */
+  D_USAGE, 0x31,                      /*     USAGE (Y) */
+  D_USAGE, 0x38,                      /*     USAGE (Wheel) */
+  D_LOGICAL_MINIMUM, 0x81,                      /*     LOGICAL_MINIMUM (-127) */
+  D_LOGICAL_MAXIMUM, 0x7f,                      /*     LOGICAL_MAXIMUM (127) */
+  D_REPORT_SIZE, 0x08,                      /*     REPORT_SIZE (8) */
+  D_REPORT_COUNT, 0x03,                      /*     REPORT_COUNT (3) */
+  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE), /*     INPUT (Data,Var,Rel) */
 
   /* Horizontal wheel */
-  D_COLLECTION, D_LOGICAL,                        //     COLLECTION (Logical)
-  D_USAGE, 0x48,                                  //      USAGE (Resolution Multiplier)
-  D_POP,                                          //       POP
-  D_FEATURE, (D_DATA|D_VARIABLE|D_ABSOLUTE),      //       FEATURE (Data,Var,Abs)
-  D_PHYSICAL_MINIMUM, 0x00,                       //       PHYSICAL_MINIMUM (0)     -- padding start
-  D_PHYSICAL_MAXIMUM, 0x00,                       //       PHYSICAL_MAXIMUM (0)
-  D_REPORT_SIZE, 0x04,                            //       REPORT_SIZE (4)
-  D_FEATURE, (D_CONSTANT|D_VARIABLE|D_ABSOLUTE),  //       FEATURE (Const,Var,Abs)  -- padding end
-  D_USAGE_PAGE, D_PAGE_CONSUMER,                  //      USAGE_PAGE (Consumer)
-  D_PAGE_ORDINAL, 0x38, 0x02,                     //       PAGE (AC Pan)
-  D_LOGICAL_MINIMUM, 0x81,                        //       LOGICAL_MINIMUM (-127)
-  D_LOGICAL_MAXIMUM, 0x7f,                        //       LOGICAL_MAXIMUM (127)
-  D_REPORT_SIZE, 0x08,                            //       REPORT_SIZE (8)
-  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //       INPUT (Data,Var,Rel)
-  D_END_COLLECTION,                               //     END_COLLECTION
-
+  D_USAGE_PAGE, D_PAGE_CONSUMER, /* USAGE_PAGE (Consumer Device) */
+  D_PAGE_ORDINAL, 0x38, 0x02,
+  D_LOGICAL_MINIMUM, 0x81,
+  D_LOGICAL_MAXIMUM, 0x7f,
+  D_REPORT_SIZE, 0x08,
+  D_REPORT_COUNT, 0x01,
+  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),
   /* End */
-  D_END_COLLECTION                                // END_COLLECTION
+  D_END_COLLECTION                            /* END_COLLECTION */
 };
+
 
 Mouse_::Mouse_(void) {
   static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));


### PR DESCRIPTION
As it turns out, the *real* problem was two typos, `D_USAGE_MINIMUM` and `D_USAGE_MAXIMUM` were used in the horizontal wheel descriptor instead of `D_LOGICAL_MINIMUM` and `D_LOGICAL_MAXIMUM`.

This patch reverts the previous USB HID descriptor rework, and fixes the horizontal wheel descriptor only, saving us some 46 bytes of program space.

Tested & works on Linux, but to make sure we don't re-break OSX, testing there would be most appreciated.