### PR TITLE
Various BootKeyboard updates

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -196,6 +196,10 @@ uint8_t BootKeyboard_::getProtocol(void) {
   return protocol;
 }
 
+void BootKeyboard_::setProtocol(uint8_t protocol) {
+  this->protocol = protocol;
+}
+
 int BootKeyboard_::sendReport(void) {
   if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
     // if the two reports are different, send a report

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -92,7 +92,7 @@ int BootKeyboard_::getDescriptor(USBSetup& setup) {
 
   // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
   // due to the USB specs, but Windows and Linux just assumes its in report mode.
-  protocol = HID_REPORT_PROTOCOL;
+  protocol = default_protocol;
 
   return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorKeyboard, sizeof(_hidReportDescriptorKeyboard));
 }

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -39,17 +39,6 @@ static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
   0x95, 0x08,                      /*   REPORT_COUNT (8) */
   0x81, 0x02,                      /*   INPUT (Data,Var,Abs) */
 
-  /* Reserved byte, used for consumer reports, only works with linux */
-  /* NOT CURRENTLY USED BY THIS IMPLEMENTATION */
-  0x05, 0x0C,             		 /*   Usage Page (Consumer) */
-  0x95, 0x01,                      /*   REPORT_COUNT (1) */
-  0x75, 0x08,                      /*   REPORT_SIZE (8) */
-  0x15, 0x00,                      /*   LOGICAL_MINIMUM (0) */
-  0x26, 0xFF, 0x00,                /*   LOGICAL_MAXIMUM (255) */
-  0x19, 0x00,                      /*   USAGE_MINIMUM (0) */
-  0x29, 0xFF,                      /*   USAGE_MAXIMUM (255) */
-  0x81, 0x00,                      /*   INPUT (Data,Ary,Abs) */
-
   /* 5 LEDs for num lock etc, 3 left for advanced, custom usage */
   0x05, 0x08,						 /*   USAGE_PAGE (LEDs) */
   0x19, 0x01,						 /*   USAGE_MINIMUM (Num Lock) */

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -53,7 +53,8 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   int sendReport(void);
 
-
+  boolean isModifierActive(uint8_t k);
+  boolean wasModifierActive(uint8_t k);
 
   uint8_t getLeds(void);
   uint8_t getProtocol(void);
@@ -86,7 +87,7 @@ class BootKeyboard_ : public PluggableUSBModule {
 
 
  protected:
-  HID_BootKeyboardReport_Data_t _keyReport;
+  HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;
 
   // Implementation of the PUSBListNode
   int getInterface(uint8_t* interfaceCount);

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -84,6 +84,7 @@ class BootKeyboard_ : public PluggableUSBModule {
     featureLength |= 0x8000;
   }
 
+  uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
  protected:
   HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -57,6 +57,7 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   uint8_t getLeds(void);
   uint8_t getProtocol(void);
+  void setProtocol(uint8_t protocol);
   void wakeupHost(void);
 
   void setFeatureReport(void* report, int length) {

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -35,10 +35,9 @@ typedef union {
   // Low level key report: up to 6 keys and shift, ctrl etc at once
   struct {
     uint8_t modifiers;
-    uint8_t reserved;
     uint8_t keycodes[6];
   };
-  uint8_t keys[8];
+  uint8_t keys[7];
 } HID_BootKeyboardReport_Data_t;
 
 

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -58,32 +58,6 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t getLeds(void);
   uint8_t getProtocol(void);
   void setProtocol(uint8_t protocol);
-  void wakeupHost(void);
-
-  void setFeatureReport(void* report, int length) {
-    if (length > 0) {
-      featureReport = (uint8_t*)report;
-      featureLength = length;
-
-      // Disable feature report by default
-      disableFeatureReport();
-    }
-  }
-
-  int availableFeatureReport(void) {
-    if (featureLength < 0) {
-      return featureLength & ~0x8000;
-    }
-    return 0;
-  }
-
-  void enableFeatureReport(void) {
-    featureLength &= ~0x8000;
-  }
-
-  void disableFeatureReport(void) {
-    featureLength |= 0x8000;
-  }
 
   uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
@@ -100,10 +74,5 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t idle;
 
   uint8_t leds;
-
-  uint8_t* featureReport;
-  int featureLength;
 };
 extern BootKeyboard_ BootKeyboard;
-
-


### PR DESCRIPTION
This does a couple of things:

- Guards `sendReport` the way it is guarded elsewhere too.
- Adds `isModifierActive` and `wasModifierActive`.
- Remove the (unused) consumer reports from the HID descriptor.
- Add a way to set a default protocol (USB spec says we should default to report, which is what BootKeyboard did, but some situations prefer defaulting to boot - this allows us to do that).
- Add a way to forcibly set the protocol.

These are changes lifted out of #20, without the fallback parts, as that will be implemented elsewhere.