### PR TITLE
Mouse: Spin out the Wheel USAGE

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -58,6 +58,7 @@ static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
   D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
   D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
   D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x01,                           //     REPORT_COUNT (1)
   D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
 
   /* End */

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -41,15 +41,22 @@ static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
   D_REPORT_SIZE, 0x01,                            //     REPORT_SIZE (1)
   D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),        //     INPUT (Data,Var,Abs)
 
-  /* X, Y, Wheel */
+  /* X, Y */
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           //    USAGE_PAGE (Generic Desktop)
   D_USAGE, 0x30,                                  //     USAGE (X)
   D_USAGE, 0x31,                                  //     USAGE (Y)
+  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x02,                           //     REPORT_COUNT (1)
+  D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
+
+  /* Vertical wheel */
   D_USAGE, 0x38,                                  //     USAGE (Wheel)
   D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
   D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
   D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
-  D_REPORT_COUNT, 0x03,                           //     REPORT_COUNT (3)
+  D_REPORT_COUNT, 0x01,                           //     REPORT_COUNT (1)
   D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
 
   /* Horizontal wheel */


### PR DESCRIPTION
Built on top of #27, in case that PR alone does not fix #25. If #27 does it, this PR becomes moot, and should not be applied.

What it does, is split up the `X, Y, Wheel` USAGE block into `X, Y` and `Wheel`. The report will be the same, but the descriptor is different. Subtle difference, but perhaps important.

My gut feeling is that this won't be needed. Nevertheless, posting it here so it can be tested in case it is required.