### PR TITLE
Improved workaround for ChromeOS modifier bug

### DIFF
--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -142,16 +142,10 @@ int Keyboard_::sendReport(void) {
   // ChromeOS 51-60 (at least) bug: if a modifier and a normal keycode are added in the
   // same report, in some cases the shift is not applied (e.g. `shift`+`[` doesn't yield
   // `{`). To compensate for this, check to see if the modifier byte has changed. If so,
-  // check to see if any modifier keys have been pressed (probably not necessary to do
-  // this step, actually). If so, copy the modifier byte to the previous key report, and
-  // resend it before proceeding.
-  uint8_t mods_changed = lastKeyReport.modifiers ^ keyReport.modifiers;
-  if (mods_changed) {
-    uint8_t mods_pressed = keyReport.modifiers & mods_changed;
-    if (mods_pressed) {
-      lastKeyReport.modifiers = keyReport.modifiers;
-      HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
-    }
+  // copy the modifier byte to the previous key report, and resend it before proceeding.
+  if (lastKeyReport.modifiers != keyReport.modifiers) {
+    lastKeyReport.modifiers = keyReport.modifiers;
+    HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
   }
 
   // If the last report is different than the current report, then we need to send a report.


### PR DESCRIPTION
In Kaleidoscope/src/kaleidoscope/hid.cpp, there is a description of a ChromeOS bug that causes certain modifier keys to be missed if they are added in the same Keyboard HID report as a printable keycode (e.g. `shift`+`[`). The workaround there sends an extra report any time `hid::pressKey()` is called with a `Key` that has a modifier flag bit set. That solves the problem in one case, but there are other ways for a report to get sent with both a new modifier and a new normal keycode. There is also the possibility that a plugin might want to stop that report from being sent, and there's also the problem that calling `pressKey()` for a modified key when the report is only partially complete could cause unintentional key release events.

This change is a general fix for the problem, regardless of how the bits in the key report got set. I added a check to `Keyboard.sendReport()` to test if any modifier bits changed, and if so, if any were pressed (though we should probably skip that extra check). If so, it copies the modifier byte from the new keyboard report to the old one, and re-sends the (modified) old report before proceeding to compare the old report with the new one, and sending the new report. Waiting to address the problem until `sendReport()` is called should correctly deal with all of the aforementioned issues, though this solution is more complex than the previous one.
