### PR TITLE
Added a 10ms delay to work around a problem with Windows Remote Desktop

### DIFF
--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -149,6 +149,15 @@ int Keyboard_::sendReport(void) {
     int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
     if (returnCode < 0)
       lastKeyReport.modifiers = last_mods;
+    // For Windows Remote Desktop, the problem is even worse. Even if the modifier is sent
+    // in a separate report, if one or more other keycodes are added in a subsequent
+    // report that comes too soon (probably before the next "frame" is sent to the remote
+    // host), it seems that the two reports get combined, and we once again see the
+    // problem. So, if both a modifier keycode and a non-modified keycode have changed in
+    // one report, we add a delay between the modifier report (sent above) and the other
+    // report (sent below). 10ms seems to work well.
+    if (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))
+      delay(10);
   }
 
   // If the last report is different than the current report, then we need to send a report.

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -149,6 +149,8 @@ int Keyboard_::sendReport(void) {
     int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
     if (returnCode < 0)
       lastKeyReport.modifiers = last_mods;
+
+#if defined(KEYBOARDIOHID_ENABLE_WINDOWS_REMOTE_DESKTOP_WORKAROUND)
     // For Windows Remote Desktop, the problem is even worse. Even if the modifier is sent
     // in a separate report, if one or more other keycodes are added in a subsequent
     // report that comes too soon (probably before the next "frame" is sent to the remote
@@ -158,6 +160,8 @@ int Keyboard_::sendReport(void) {
     // report (sent below). 10ms seems to work well.
     if (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))
       delay(10);
+#endif
+
   }
 
   // If the last report is different than the current report, then we need to send a report.

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -150,16 +150,16 @@ int Keyboard_::sendReport(void) {
     if (returnCode < 0)
       lastKeyReport.modifiers = last_mods;
 
-#if defined(KEYBOARDIOHID_ENABLE_WINDOWS_REMOTE_DESKTOP_WORKAROUND)
+#if defined(KEYBOARDIOHID_MODIFIER_FLAG_DELAY)
     // For Windows Remote Desktop, the problem is even worse. Even if the modifier is sent
     // in a separate report, if one or more other keycodes are added in a subsequent
     // report that comes too soon (probably before the next "frame" is sent to the remote
     // host), it seems that the two reports get combined, and we once again see the
     // problem. So, if both a modifier keycode and a non-modified keycode have changed in
     // one report, we add a delay between the modifier report (sent above) and the other
-    // report (sent below). 10ms seems to work well.
+    // report (sent below).
     if (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))
-      delay(10);
+      delay(KEYBOARDIOHID_MODIFIER_FLAG_DELAY);
 #endif
 
   }


### PR DESCRIPTION
This change addresses a problem that has been observed with Windows Remote Desktop. It's basically the same issue as the ChromeOS bug, but a bit worse, because two HID reports that are sent to the local host from the Keyboard with a very small interval seem to be collapsed into a single report sent to the remote host, and the modifier keycodes appear to be processed last, so they don't get applied until after the unmodified keycode(s) in the report.

This report introduces a delay of 10ms if a report will be sent that changes both the modifiers byte and some other keycode in the keyboard HID report. If so, it will send the modifier in one report, delay for 10ms, then send the full report. Several different delay intervals were [tested by a user on the community forum](https://community.keyboard.io/t/trouble-tipping-shifted-characters-over-a-remote-desktop-connection/1162/4?u=merlin), who reported that a delay of 10ms was sufficient, but a delay of 5ms would occasionally result in an unintended unmodified character.

I don't like using `delay()` much, but I've done what I can to keep it from happening spuriously, and this is the best solution to the problem that I've come up with. On the other hand, users of Windows Remote Desktop are probably not a high percentage of total users, and there are other ways for them to get around this problem, though right now, those other techniques are likely to introduce other problems for them (scan order bugs with repeated characters).