### PR TITLE
BootKeyboard: default to BOOT protocol

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -68,7 +68,7 @@ static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
   D_END_COLLECTION
 };
 
-BootKeyboard_::BootKeyboard_(void) : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1), leds(0) {
+BootKeyboard_::BootKeyboard_(void) : PluggableUSBModule(1, 1, epType), protocol(HID_BOOT_PROTOCOL), idle(1), leds(0) {
   epType[0] = EP_TYPE_INTERRUPT_IN;
   PluggableUSB().plug(this);
 }

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -60,7 +60,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t getProtocol(void);
   void setProtocol(uint8_t protocol);
 
-  uint8_t default_protocol = HID_REPORT_PROTOCOL;
+  uint8_t default_protocol = HID_BOOT_PROTOCOL;
 
  protected:
   HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -60,6 +60,35 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t getProtocol(void);
   void setProtocol(uint8_t protocol);
 
+  /* The USB specification says that keyboards should start with
+   * HID_REPORT_PROTOCOL as a default, and yet, we default to HID_BOOT_PROTOCOL
+   * instead. We do this to support operating systems that require the keyboard
+   * to default to boot protocol during negotiation in order to enable them to
+   * wake the host up. This includes Linux, MacOS, and Windows. If the keyboard
+   * conforms to the spec, and starts in report mode, it will work under these
+   * operating systems, but if they are suspended, the keyboard will not be
+   * allowed to wake them up.
+   *
+   * Furthermore, there are BIOSes out there that do not implement a HID
+   * descriptor parser, nor do they explicitly send a SET_PROTOCOL request to
+   * put the keyboard into boot protocol. For these to work, we need to default
+   * to boot protocol.
+   *
+   * We could - and for some time, did - work the first issue around by having
+   * another end-point that implements a boot-keyboard, with boot-protocol as
+   * default. Sadly, that has side-effects too: some BIOSes, Grub, and OSX's
+   * FileVault gets easily confused, and will use the first node of a device. If
+   * that happens to be the dummy wakeup-only keyboard, then the keyboard will
+   * be unusable.
+   *
+   * There is no reliable way to support all these scenarios while still
+   * conforming to the specification.
+   *
+   * Luckily for us, all three major OSes are fine with boot being the default,
+   * they will all explicitly set the protocol to report. Any spec-conforming
+   * host will also work fine with boot being the default, because they are
+   * required - by spec - to set the protocol themselves.
+   */
   uint8_t default_protocol = HID_BOOT_PROTOCOL;
 
  protected:


### PR DESCRIPTION
The primary reason for this change is to allow us to get rid of WakeupKeyboard in HostPowerManagement, because having two boot-keyboard enabled endpoints has the chance of confusing the hell out of certain operating systems, bootloaders, or BIOSes. As in, whichever gets found first, wins, which becomes a problem when WakeupKeyboard wins: that one does not implement a real keyboard. If it wins, one will be able to wake up a sleeping systems, but will be unable to type. That is not behaviour we desire.

If we drop WakeupKeyboard, we need another way to have a boot-proto-enabled keyboard that defaults to boot proto, which is what this patch does with BootKeyboard.

The reason we need to default to BOOT, contrary to what the USB spec says, is because Linux, Windows and OSX will only enable wakeup-support for a keyboard if it defaults to boot. Even if we say we support wakeup, even if we can switch to boot mode, if that is not the default, they will disable wakeup by default. That is not something we desire, either.

So, we default to boot. This should work everywhere, and does so on all three major OSes. It also makes the firmware work out of the box on FreeBSD, which doesn't support the report protocol at all.
