### PR TITLE
BootKeyboard: Fix modifier release

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -249,7 +249,7 @@ size_t BootKeyboard_::press(uint8_t k) {
 size_t BootKeyboard_::release(uint8_t k) {
   if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
     // it's a modifier key
-    _keyReport.modifiers = _keyReport.modifiers & (~(0x01 << (k - HID_KEYBOARD_LAST_MODIFIER)));
+    _keyReport.modifiers = _keyReport.modifiers & (~(0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER)));
   } else {
     // it's some other key:
     // Test the key report to see if k is present.  Clear it if it exists.


### PR DESCRIPTION
When releasing a modifier, we were computing the bit index wrong: we substracted `HID_KEYBOARD_LAST_MODIFIER` from the keycode (going into negatives and wrapping around) instead of `HID_KEYBOARD_FIRST_MODIFIER`. Computing the index wrong meant that `BootKeyboard.release(Key_LeftShift.keyCode)` never cleared the shift bit from `_keyReport.modifiers`. This had undesired effects when BootKeyboard was active, and we explicitly wanted to release a single key, but keep the rest of the report intact.
