### PR TITLE
BootKeyboard: Disable HID_SET_IDLE

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -154,7 +154,14 @@ bool BootKeyboard_::setup(USBSetup& setup) {
       return true;
     }
     if (request == HID_SET_IDLE) {
+      // We currently ignore SET_IDLE, because we don't really do anything with it, and implementing
+      // it causes issues on OSX, such as key chatter. Other operating systems do not suffer if we
+      // force this to zero, either.
+#if 0
       idle = setup.wValueL;
+#else
+      idle = 0;
+#endif
       return true;
     }
     if (request == HID_SET_REPORT) {


### PR DESCRIPTION
Because OSX behaves strangely when HID_SET_IDLE is implemented (symptoms include key chatter), we disable it for now. Other operating systems to not suffer if we force the idle setting to zero, either.