### PR TITLE
Mouse: Implement Mouse_::stop()

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -93,6 +93,17 @@ void Mouse_::move(signed char x, signed char y, signed char vWheel, signed char 
   report.hWheel = hWheel;
 }
 
+void Mouse_::stop(bool x, bool y, bool vWheel, bool hWheel) {
+  if (x)
+    report.xAxis = 0;
+  if (y)
+    report.yAxis = 0;
+  if (vWheel)
+    report.vWheel = 0;
+  if (hWheel)
+    report.hWheel = 0;
+}
+
 void Mouse_::releaseAll(void) {
   memset(&report, 0, sizeof(report));
 }

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -49,6 +49,17 @@ class Mouse_ {
   void end(void);
   void click(uint8_t b = MOUSE_LEFT);
   void move(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
+  /** stop() stops mouse and/or mouse wheel movement in given directions.
+   *
+   * Counterpart of move(), this function allows us to undo whatever movement we
+   * were supposed to make. The intended use-case is one where we send multiple
+   * reports per cycle, and want greater control over them, when we don't want
+   * to clear the whole report, just parts of it.
+   *
+   * Any of the arguments that is set to true, will be cleared from the report
+   * to be sent by the next call to sendReport().
+   */
+  void stop(bool x, bool y, bool vWheel = false, bool hWheel = false);
   void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
   void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
   bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default


### PR DESCRIPTION
This mirrors `move()`, and the intent is to use it when releasing a mouse key outside of the main event loop (such as during a macro).
