### PR TITLE
Replace ::stop() with ::getReport()

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -93,17 +93,6 @@ void Mouse_::move(signed char x, signed char y, signed char vWheel, signed char 
   report.hWheel = hWheel;
 }
 
-void Mouse_::stop(bool x, bool y, bool vWheel, bool hWheel) {
-  if (x)
-    report.xAxis = 0;
-  if (y)
-    report.yAxis = 0;
-  if (vWheel)
-    report.vWheel = 0;
-  if (hWheel)
-    report.hWheel = 0;
-}
-
 void Mouse_::releaseAll(void) {
   memset(&report, 0, sizeof(report));
 }

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -49,21 +49,19 @@ class Mouse_ {
   void end(void);
   void click(uint8_t b = MOUSE_LEFT);
   void move(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
-  /** stop() stops mouse and/or mouse wheel movement in given directions.
-   *
-   * Counterpart of move(), this function allows us to undo whatever movement we
-   * were supposed to make. The intended use-case is one where we send multiple
-   * reports per cycle, and want greater control over them, when we don't want
-   * to clear the whole report, just parts of it.
-   *
-   * Any of the arguments that is set to true, will be cleared from the report
-   * to be sent by the next call to sendReport().
-   */
-  void stop(bool x, bool y, bool vWheel = false, bool hWheel = false);
   void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
   void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
   bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default
 
+  /** getReport returns the current report.
+   *
+   * The current report is the one to be send next time sendReport() is called.
+   *
+   * @returns A copy of the report.
+   */
+  const HID_MouseReport_Data_t getReport() {
+    return report;
+  }
   void sendReport(void);
 
   void releaseAll(void);


### PR DESCRIPTION
Instead of providing a ::stop() method, provide ::getReport() instead, allowing stop()-like functionality to be implemented on top of that and ::move().
