### PR TITLE
Add functions for determining whether any modifiers are/were active

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -345,4 +345,18 @@ boolean BootKeyboard_::wasModifierActive(uint8_t k) {
   return false;
 }
 
+/* Returns true if any modifier key will be sent during this key report
+ * Returns false in all other cases
+ * */
+boolean BootKeyboard_::isAnyModifierActive() {
+  return _keyReport.modifiers > 0;
+}
+
+/* Returns true if any modifier key was being sent during the previous key report
+ * Returns false in all other cases
+ * */
+boolean BootKeyboard_::wasAnyModifierActive() {
+  return _lastKeyReport.modifiers > 0;
+}
+
 BootKeyboard_ BootKeyboard;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -57,6 +57,8 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   boolean isModifierActive(uint8_t k);
   boolean wasModifierActive(uint8_t k);
+  boolean isAnyModifierActive();
+  boolean wasAnyModifierActive();
   boolean isKeyPressed(uint8_t k);
   boolean wasKeyPressed(uint8_t k);
 

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -173,6 +173,20 @@ boolean Keyboard_::wasModifierActive(uint8_t k) {
   return false;
 }
 
+/* Returns true if *any* modifier will be sent during this key report
+ * Returns false in all other cases
+ * */
+boolean Keyboard_::isAnyModifierActive() {
+  return keyReport.modifiers > 0;
+}
+
+/* Returns true if *any* modifier was being sent during the previous key report
+ * Returns false in all other cases
+ * */
+boolean Keyboard_::wasAnyModifierActive() {
+  return lastKeyReport.modifiers > 0;
+}
+
 
 /* Returns true if the non-modifier key passed in will be sent during this key report
  * Returns false in all other cases

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -62,6 +62,8 @@ class Keyboard_ {
   boolean wasKeyPressed(uint8_t k);
   boolean isModifierActive(uint8_t k);
   boolean wasModifierActive(uint8_t k);
+  boolean isAnyModifierActive();
+  boolean wasAnyModifierActive();
 
   uint8_t getLEDs() { return HID().getLEDs(); };
 


### PR DESCRIPTION
Part of the resolution for [532 on Kaleidoscope](https://github.com/keyboardio/Kaleidoscope/issues/532).