### PR TITLE
Added keyboard report stash and restore functions

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -359,4 +359,20 @@ boolean BootKeyboard_::wasAnyModifierActive() {
   return _lastKeyReport.modifiers > 0;
 }
 
+/* Saves a backup copy of the current report, then copies the previous report to the
+ * current one. This should be called by a plugin (via HIDAdaptor) that needs to send a
+ * report mid-cycle, when the current keyboard report is incomplete.
+ * */
+void BootKeyboard_::stashReport() {
+  stashed_key_report_ = _keyReport;
+  _keyReport = _lastKeyReport;
+}
+
+/* Restores the stashed copy of the current keyboard report
+ * Should be called by a plugin (via HIDAdaptor) after a mid-cycle report is sent
+ * */
+void BootKeyboard_::restoreReport() {
+  _keyReport = stashed_key_report_;
+}
+
 BootKeyboard_ BootKeyboard;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -68,8 +68,12 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
+  void stashReport();
+  void restoreReport();
+
  protected:
   HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;
+  HID_BootKeyboardReport_Data_t stashed_key_report_;
 
   // Implementation of the PUSBListNode
   int getInterface(uint8_t* interfaceCount);

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -257,4 +257,20 @@ void Keyboard_::releaseAll(void) {
   memset(&keyReport.allkeys, 0x00, sizeof(keyReport.allkeys));
 }
 
+/* Saves a backup copy of the current report, then copies the previous report to the
+ * current one. This should be called by a plugin (via HIDAdaptor) that needs to send a
+ * report mid-cycle, when the current keyboard report is incomplete.
+ * */
+void Keyboard_::stashReport() {
+  stashed_key_report_ = keyReport;
+  keyReport = lastKeyReport;
+}
+
+/* Restores the stashed copy of the current keyboard report
+ * Should be called by a plugin (via HIDAdaptor) after a mid-cycle report is sent
+ * */
+void Keyboard_::restoreReport() {
+  keyReport = stashed_key_report_;
+}
+
 Keyboard_ Keyboard;

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -67,9 +67,14 @@ class Keyboard_ {
 
   uint8_t getLEDs() { return HID().getLEDs(); };
 
+  void stashReport();
+  void restoreReport();
+
+ private:
   HID_KeyboardReport_Data_t keyReport;
   HID_KeyboardReport_Data_t lastKeyReport;
- private:
+  HID_KeyboardReport_Data_t stashed_key_report_;
+
   int sendReportUnchecked(void);
 };
 extern Keyboard_ Keyboard;


### PR DESCRIPTION
This PR adds two functions to each keyboard HID reporter class (`Keyboard` & `BootKeyboard`):

- `stashReport()`: To be used when a plugin needs to send a mid-cycle report. It saves a copy of the current report, then overwrites the current report with the previous one so that a complete report can be modified, rather than sending a partial report.
- `restoreReport()`: To be used after a mid-cycle report has been sent. It restores the state of the current report to what it was before the call to `stashReport()`, so that it can resume where it left off.

In order to do this, I introduced a new member variable to store the stashed copy – `stashed_key_report_`. And, in the case of the MultiReport `Keyboard` class, I moved the other two report data members from the public to private section, because the stash functions replace the reason they were made public in the first place.

I did not rename these variables in order to avoid mixing different logical changes in the same PR.