### PR TITLE
Demo of boot protocol working

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -141,6 +141,11 @@ bool BootKeyboard_::setup(USBSetup& setup) {
     }
     if (request == HID_GET_PROTOCOL) {
       // TODO improve
+      // This is where the `protocol` variable is used to set...something, but I don't
+      // know what. With the change that I've made to use `boot_protocol_` instead, this
+      // would always be set to `HID_REPORT_PROTOCOL`, even when sending boot protocol
+      // reports (successfully). It doesn't seem correct, but it works on macOS and Linux
+      // (or at least, my old Ubuntu machine).
       UEDATX = protocol;
       return true;
     }

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -196,15 +196,29 @@ uint8_t BootKeyboard_::getLeds(void) {
 }
 
 uint8_t BootKeyboard_::getProtocol(void) {
-  return protocol;
+  if (boot_protocol_) {
+    return HID_BOOT_PROTOCOL;
+  } else {
+    return HID_REPORT_PROTOCOL;
+  }
 }
 
 void BootKeyboard_::setProtocol(uint8_t protocol) {
-  this->protocol = protocol;
+  if (protocol == HID_BOOT_PROTOCOL) {
+    boot_protocol_ = true;
+  } else {
+    boot_protocol_ = false;
+  }
 }
 
 int BootKeyboard_::sendReport(void) {
   if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
+    Serial.print(F("sending boot report: "));
+    for (byte i{0}; i < 8; ++i) {
+      Serial.print(F(" "));
+      Serial.print(int(_keyReport.bytes[i]));
+    }
+    Serial.println();
     // if the two reports are different, send a report
     int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
     memcpy(&_lastKeyReport, &_keyReport, sizeof(_keyReport));

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -216,7 +216,7 @@ int BootKeyboard_::sendReport(void) {
     Serial.print(F("sending boot report: "));
     for (byte i{0}; i < 8; ++i) {
       Serial.print(F(" "));
-      Serial.print(int(_keyReport.bytes[i]));
+      Serial.print(_keyReport.bytes[i], HEX);
     }
     Serial.println();
     // if the two reports are different, send a report

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -78,6 +78,7 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   uint8_t epType[1];
   uint8_t protocol;
+  bool boot_protocol_{false};
   uint8_t idle;
 
   uint8_t leds;

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -101,7 +101,7 @@ int Keyboard_::sendReportUnchecked(void) {
   Serial.print(F("sending nkro report:"));
   for (byte i{0}; i < 29; ++i) {
     Serial.print(F(" "));
-    Serial.print(int(keyReport.allkeys[i]));
+    Serial.print(keyReport.allkeys[i], HEX);
   }
   Serial.println();
     return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -98,6 +98,12 @@ void Keyboard_::end(void) {
 }
 
 int Keyboard_::sendReportUnchecked(void) {
+  Serial.print(F("sending nkro report:"));
+  for (byte i{0}; i < 29; ++i) {
+    Serial.print(F(" "));
+    Serial.print(int(keyReport.allkeys[i]));
+  }
+  Serial.println();
     return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));
 }
 


### PR DESCRIPTION
I'm submitting this as a PR, rather than an issue, because I want to discuss the code very specifically, and this is a much simpler way to present it, and make it easy for others to test it on systems that I don't have access to. I'm creating it as a draft PR, and do not intend for it to be merged, as it contains debugging code for demonstration purposes. Please forgive me if I get some of the terminology wrong; I'm still not clear on much of it.

### Background

I've been working on my own version of the keyboard HID module, based on KeyboardioHID, and had NKRO "report" protocol working just fine. I wanted to add 6KRO "boot" protocol support to it, and ran into some trouble getting it to work. It seemed like the problem was that my primary machine (an iMac running Mojave) was rejecting attempts to send boot protocol reports when the keyboard was advertising a report protocol HID endpoint to the host. So I started testing out Kaleidoscope itself, and making very small changes to KeyboardioHID, I stumbled on something that seems to work.

### The "Solution"?

The change that I made seems like it shouldn't work. I had configured a Macro key to switch the keyboard from report protocol to boot protocol by using the USBQuirks plugin, but that didn't seem to work on either my iMac or my (rather old) Linux (Ubuntu) machine. I would switch modes, and it either wouldn't work at all (no output on the host, with quarter-second delays every time a 6KRO report was attempted), or it would switch itself back into NKRO mode. Frustrated by the latter problem, I added a new variable (`BootKeyboard.boot_protocol_`), and used that as the test condition instead of `protocol`, and suddenly everything worked.

The reason it seems like it shouldn't work is that I didn't remove the `protocol` variable, so when `PluggableUSB` (presumably) calls `BootKeyboard.setup()`, it seems like the host should still expect the keyboard to be using NKRO reports. I'm stumped as to _how_, but it works, and I can easily verify that both protocols work fine on the two machines I have access to.

So, I may have stumbled on a way to improve the functioning of Kaleidoscope in this area, but I don't know if these changes break something else…

### Possible (Likely?) Problems

This code might not work on all operating systems, of course. I don't have the means to test it on ChromeOS, Windows, or any BSD variant, and the Linux machine I've got is very out-of-date. I'm not at all an expert on USB HID, and I think I've reached the limit of what I can figure out on my own.