### PR TITLE
Added a HIDReportObserver class

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "BootKeyboard.h"
 #include "DescriptorPrimitives.h"
+#include "HIDReportObserver.h"
 
 // See Appendix B of USB HID spec
 static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
@@ -217,6 +218,7 @@ int BootKeyboard_::sendReport(void) {
     if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
         // if the two reports are different, send a report
         int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
+        HIDReportObserver::observeReport(HID_REPORTID_KEYBOARD, &_keyReport, sizeof(_keyReport), returnCode);
         memcpy(&_lastKeyReport, &_keyReport, sizeof(_keyReport));
         return returnCode;
     }

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -19,6 +19,7 @@
 #ifndef KEYBOARDIOHID_BUILD_WITHOUT_HID
 
 #include "HID.h"
+#include "HIDReportObserver.h"
 
 #if defined(USBCON)
 
@@ -92,9 +93,7 @@ void HID_::AppendDescriptor(HIDSubDescriptor *node) {
 
 int HID_::SendReport(uint8_t id, const void* data, int len) {
     auto result = SendReport_(id, data, len);
-    if(send_report_hook) {
-        (*send_report_hook)(id, data, len, result);
-    }
+    HIDReportObserver::observeReport(id, data, len, result);
     return result;
 }
 

--- a/src/HID.h
+++ b/src/HID.h
@@ -89,8 +89,6 @@ class HIDSubDescriptor {
 class HID_ : public PluggableUSBModule {
   public:
 
-    typedef void(*SendReportHook)(uint8_t id, const void* data, int len, int result);
-
     HID_(void);
     int begin(void);
     int SendReport(uint8_t id, const void* data, int len);
@@ -98,13 +96,6 @@ class HID_ : public PluggableUSBModule {
     uint8_t getLEDs(void) {
         return setReportData.leds;
     };
-
-    void setSendReportHook(SendReportHook hook) {
-        send_report_hook = hook;
-    }
-    SendReportHook getCurrentSendReportHook() const {
-        return send_report_hook;
-    }
 
   protected:
     // Implementation of the PluggableUSBModule
@@ -116,8 +107,6 @@ class HID_ : public PluggableUSBModule {
     int SendReport_(uint8_t id, const void* data, int len);
   private:
     EPTYPE_DESCRIPTOR_SIZE epType[1];
-
-    SendReportHook send_report_hook = nullptr;
 
     HIDSubDescriptor* rootNode;
     uint16_t descriptorSize;

--- a/src/HIDReportObserver.cpp
+++ b/src/HIDReportObserver.cpp
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2015-2019 Keyboard.io, Inc
+
+See the readme for credit to other people.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "HIDReportObserver.h"
+
+HIDReportObserver::SendReportHook HIDReportObserver::send_report_hook_ = nullptr;

--- a/src/HIDReportObserver.h
+++ b/src/HIDReportObserver.h
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2015-2019 Keyboard.io, Inc
+
+See the readme for credit to other people.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <stdint.h>
+
+class HIDReportObserver
+{
+   public:
+
+    typedef void(*SendReportHook)(uint8_t id, const void* data, 
+                                  int len, int result);
+    
+    static void observeReport(uint8_t id, const void* data, 
+                                  int len, int result) {
+       if(send_report_hook_) {
+          (*send_report_hook_)(id, data, len, result);
+       }
+    }
+      
+    static SendReportHook currentHook() { return send_report_hook_; }
+    
+    static SendReportHook resetHook(SendReportHook new_hook) {
+       auto previous_hook = send_report_hook_;
+       send_report_hook_ = new_hook; 
+       return previous_hook;
+   }
+      
+   private:
+      
+      static SendReportHook send_report_hook_;
+};

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 */
 
 #include "SingleAbsoluteMouse.h"
+#include "HIDReportObserver.h"
 
 static const uint8_t _hidSingleReportDescriptorAbsoluteMouse[] PROGMEM = {
     D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)         54 */
@@ -109,7 +110,8 @@ bool SingleAbsoluteMouse_::setup(USBSetup& setup) {
 }
 
 void SingleAbsoluteMouse_::sendReport(void* data, int length) {
-    USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
+    auto result = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
+    HIDReportObserver::observeReport(HID_REPORTID_MOUSE_ABSOLUTE, data, length, result);
 }
 
 SingleAbsoluteMouse_ SingleAbsoluteMouse;


### PR DESCRIPTION
The new observer class is used in all places where reports are
send. It replaces the old observer that was solely used by HID.*.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>