### PR TITLE
Finalised SAMD port

### DIFF
--- a/src/HID-Settings.h
+++ b/src/HID-Settings.h
@@ -69,6 +69,12 @@ THE SOFTWARE.
 #define HID_REPORT_TYPE_OUTPUT  2
 #define HID_REPORT_TYPE_FEATURE 3
 
+// Controls whether to pack messages or not. When set, any sends will be delayed
+// until packing is toggled off, and sent then. This is a no-op on AVR, but is
+// required for SAMD. We place a forward-declaration here to be able to avoid
+// architecture-specific ifdefs elsewhere in the code.
+void USB_PackMessages(bool pack);
+
 #if defined(ARDUINO_ARCH_AVR)
 
 #include "PluggableUSB.h"

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -54,6 +54,7 @@ int HID_::getDescriptor(USBSetup& setup) {
 
     int total = 0;
     HIDSubDescriptor* node;
+    USB_PackMessages(true);
     for (node = rootNode; node; node = node->next) {
         int res = USB_SendControl(TRANSFER_PGM, node->data, node->length);
         if (res == -1)
@@ -65,6 +66,7 @@ int HID_::getDescriptor(USBSetup& setup) {
     // due to the USB specs, but Windows and Linux just assumes its in report mode.
     protocol = HID_REPORT_PROTOCOL;
 
+    USB_PackMessages(false);
     return total;
 }
 

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -26,10 +26,6 @@ THE SOFTWARE.
 #include "SystemControl.h"
 #include "DescriptorPrimitives.h"
 
-#ifdef ARDUINO_ARCH_SAMD
-#include "USB/SAMD21_USBDevice.h"
-#endif
-
 static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
     //TODO limit to system keys only?
     /*  System Control (Power Down, Sleep, Wakeup, ...) */
@@ -82,8 +78,10 @@ void SystemControl_::press(uint8_t s) {
         USBDevice.wakeupHost();
 #endif
 #ifdef ARDUINO_ARCH_SAMD
-        extern USBDevice_SAMD21G18x usbd;
-        usbd.wakeupHost();
+        // This is USBDevice_SAMD21G18x.wakeupHost(). But we can't include that
+        // header, because it redefines a few symbols, and causes linking
+        // errors. So we simply reimplement the same thing here.
+        USB->DEVICE.CTRLB.bit.UPRSM = 1;
 #endif
     } else {
         sendReport(&s, sizeof(s));

--- a/src/arch/avr.cpp
+++ b/src/arch/avr.cpp
@@ -1,0 +1,8 @@
+#include "Arduino.h"
+
+#ifdef ARDUINO_ARCH_AVR
+
+void USB_PackMessages(bool pack) {
+}
+
+#endif

--- a/src/arch/samd.cpp
+++ b/src/arch/samd.cpp
@@ -10,4 +10,8 @@ int USB_SendControl(uint8_t a, const void* b, uint8_t c) {
     USBDevice.sendControl(b, c);
 }
 
+void USB_PackMessages(bool pack) {
+  USBDevice.packMessages(pack);
+}
+
 #endif


### PR DESCRIPTION
Turns out that my previous attempts at a SAMD port weren't enough, and there are a number of things left to fix up. This patchset "fixes" the host wakeup code (previously it compiled, but failed to link), and updates a few places that need special handling on SAMD.

The host wakeup code compiles and links, but doesn't work yet. I left the attempt in regardless, because it's a pointer to where we should look when debugging it further.

Tested the updates on both AVR and SAMD, and everything appears to function correctly, apart from the wakeup on SAMD.