### PR TITLE
HID: Mark HID_::getShortName weak

### DIFF
--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -70,6 +70,7 @@ int HID_::getDescriptor(USBSetup& setup) {
     return total;
 }
 
+__attribute__((weak))
 uint8_t HID_::getShortName(char *name) {
     name[0] = 'k';
     name[1] = 'b';


### PR DESCRIPTION
Marking the method weak allows us to override it elsewhere, which in turn makes it possible to have a different shortname than 'kbio01'.

This is the first half of the fix for #54.
