### PR TITLE
Delay appending the HID descriptors until .begin()

### DIFF
--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -44,11 +44,12 @@ static const uint8_t _hidMultiReportDescriptorConsumer[] PROGMEM = {
 };
 
 ConsumerControl_::ConsumerControl_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
-    HID().AppendDescriptor(&node);
 }
 
 void ConsumerControl_::begin(void) {
+    static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
+    HID().AppendDescriptor(&node);
+
     // release all buttons
     end();
 }

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -79,11 +79,12 @@ static const uint8_t _hidMultiReportDescriptorKeyboard[] PROGMEM = {
 };
 
 Keyboard_::Keyboard_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
-    HID().AppendDescriptor(&node);
 }
 
 void Keyboard_::begin(void) {
+    static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
+    HID().AppendDescriptor(&node);
+
     // Force API to send a clean report.
     // This is important for and HID bridge where the receiver stays on,
     // while the sender is resetted.

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -45,11 +45,12 @@ static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
 };
 
 SystemControl_::SystemControl_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
-    HID().AppendDescriptor(&node);
 }
 
 void SystemControl_::begin(void) {
+    static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
+    HID().AppendDescriptor(&node);
+
     // release all buttons
     end();
 }


### PR DESCRIPTION
To be able to better control when and in which order HID descriptors are appended, delay doing so until calling `.begin()`, at least for NKRO-keyboard and Consumer- and SystemControl. The Mouse class was already doing the same.

This is a pre-requisite for #59.