### PR TITLE
Revert "Delay appending the HID descriptors until .begin()"

### DIFF
--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -44,12 +44,11 @@ static const uint8_t _hidMultiReportDescriptorConsumer[] PROGMEM = {
 };
 
 ConsumerControl_::ConsumerControl_(void) {
+    static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
+    HID().AppendDescriptor(&node);
 }
 
 void ConsumerControl_::begin(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
-    HID().AppendDescriptor(&node);
-
     // release all buttons
     end();
 }

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -79,12 +79,11 @@ static const uint8_t _hidMultiReportDescriptorKeyboard[] PROGMEM = {
 };
 
 Keyboard_::Keyboard_(void) {
+    static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
+    HID().AppendDescriptor(&node);
 }
 
 void Keyboard_::begin(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
-    HID().AppendDescriptor(&node);
-
     // Force API to send a clean report.
     // This is important for and HID bridge where the receiver stays on,
     // while the sender is resetted.

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -45,12 +45,11 @@ static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
 };
 
 SystemControl_::SystemControl_(void) {
+    static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
+    HID().AppendDescriptor(&node);
 }
 
 void SystemControl_::begin(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
-    HID().AppendDescriptor(&node);
-
     // release all buttons
     end();
 }


### PR DESCRIPTION
Reverts keyboardio/KeyboardioHID#62, because it causes issues on the Dygma Raise. With this applied, the keyboard either doesn't register:

```
[  +0.110901] usb 2-3.4.2: New USB device found, idVendor=1209, idProduct=2201, bcdDevice= 1.00                                                    
[  +0.000006] usb 2-3.4.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3                                                                
[  +0.000003] usb 2-3.4.2: Product: Dygma                                                                                                          
[  +0.000003] usb 2-3.4.2: Manufacturer: Raise                                                                                                     
[  +0.000002] usb 2-3.4.2: SerialNumber: BF00F8E650515157382E314AFF062B0BCkbio01                                                                   
[  +0.012923] cdc_acm 2-3.4.2:1.0: ttyACM0: USB ACM device                                                                                         
[  +0.004397] input: Raise Dygma as /devices/pci0000:00/0000:00:14.0/usb2/2-3/2-3.4/2-3.4.2/2-3.4.2:1.2/0003:1209:2201.0010/input/input37          
[  +0.064089] hid-generic 0003:1209:2201.0010: input,hidraw4: USB HID v1.01 Mouse [Raise Dygma] on usb-0000:00:14.0-3.4.2/input2                   
[  +0.005623] usbhid 2-3.4.2:1.3: can't add hid device: -75                                                                                        
[  +0.000020] usbhid: probe of 2-3.4.2:1.3 failed with error -75
```

Or, when using the `driver/hid` branch of Kaleidoscope (keyboardio/Kaleidoscope#771), the keyboard registers, but whenever I press a key:

```
[  +1.738457] usb 2-3.4.2: input irq status -75 received
```

If that `-75` is `-errno`, then it's `EOVERFLOW`: "Value too large for defined data type".