### PR TITLE
Conform to Kaleidoscope C++ coding style

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,7 @@
+style=google
+unpad-paren
+pad-header
+pad-oper
+indent-classes
+indent=spaces=2
+max-continuation-indent=80

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ EXAMPLES_HEX := $(addsuffix .hex,${EXAMPLES})
 
 
 astyle:
-		find . -type f -name \*.cpp |xargs -n 1 astyle --style=google
-		find . -type f -name \*.ino |xargs -n 1 astyle --style=google
-		find . -type f -name \*.h |xargs -n 1 astyle --style=google
+	astyle --project --recursive "src/*.cpp,*.h,*.ino"
 
 smoke: ${EXAMPLES_HEX}
 

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -312,7 +312,7 @@ void BootKeyboard_::releaseAll() {
 /* Returns true if the non-modifer key passed in will be sent during this key report
  * Returns false in all other cases
  * */
-boolean BootKeyboard_::isKeyPressed(uint8_t k) {
+bool BootKeyboard_::isKeyPressed(uint8_t k) {
   for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
     if (_keyReport.keycodes[i] == k) {
       return true;
@@ -324,7 +324,7 @@ boolean BootKeyboard_::isKeyPressed(uint8_t k) {
 /* Returns true if the non-modifer key passed in was sent during the previous key report
  * Returns false in all other cases
  * */
-boolean BootKeyboard_::wasKeyPressed(uint8_t k) {
+bool BootKeyboard_::wasKeyPressed(uint8_t k) {
   for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
     if (_lastKeyReport.keycodes[i] == k) {
       return true;
@@ -338,7 +338,7 @@ boolean BootKeyboard_::wasKeyPressed(uint8_t k) {
 /* Returns true if the modifer key passed in will be sent during this key report
  * Returns false in all other cases
  * */
-boolean BootKeyboard_::isModifierActive(uint8_t k) {
+bool BootKeyboard_::isModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
     return !!(_keyReport.modifiers & (1 << k));
@@ -349,7 +349,7 @@ boolean BootKeyboard_::isModifierActive(uint8_t k) {
 /* Returns true if the modifer key passed in was being sent during the previous key report
  * Returns false in all other cases
  * */
-boolean BootKeyboard_::wasModifierActive(uint8_t k) {
+bool BootKeyboard_::wasModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
     return !!(_lastKeyReport.modifiers & (1 << k));
@@ -360,14 +360,14 @@ boolean BootKeyboard_::wasModifierActive(uint8_t k) {
 /* Returns true if any modifier key will be sent during this key report
  * Returns false in all other cases
  * */
-boolean BootKeyboard_::isAnyModifierActive() {
+bool BootKeyboard_::isAnyModifierActive() {
   return _keyReport.modifiers > 0;
 }
 
 /* Returns true if any modifier key was being sent during the previous key report
  * Returns false in all other cases
  * */
-boolean BootKeyboard_::wasAnyModifierActive() {
+bool BootKeyboard_::wasAnyModifierActive() {
   return _lastKeyReport.modifiers > 0;
 }
 

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -29,200 +29,200 @@ THE SOFTWARE.
 
 // See Appendix B of USB HID spec
 static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
-    //  Keyboard
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,
-    D_USAGE, D_USAGE_KEYBOARD,
+  //  Keyboard
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,
+  D_USAGE, D_USAGE_KEYBOARD,
 
-    D_COLLECTION, D_APPLICATION,
-    // Modifiers
-    D_USAGE_PAGE, D_PAGE_KEYBOARD,
-    D_USAGE_MINIMUM, 0xe0,
-    D_USAGE_MAXIMUM, 0xe7,
-    D_LOGICAL_MINIMUM, 0x0,
-    D_LOGICAL_MAXIMUM, 0x1,
-    D_REPORT_SIZE, 0x1,
-    D_REPORT_COUNT, 0x8,
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),
+  D_COLLECTION, D_APPLICATION,
+  // Modifiers
+  D_USAGE_PAGE, D_PAGE_KEYBOARD,
+  D_USAGE_MINIMUM, 0xe0,
+  D_USAGE_MAXIMUM, 0xe7,
+  D_LOGICAL_MINIMUM, 0x0,
+  D_LOGICAL_MAXIMUM, 0x1,
+  D_REPORT_SIZE, 0x1,
+  D_REPORT_COUNT, 0x8,
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
 
-    // Reserved byte
-    D_REPORT_COUNT, 0x1,
-    D_REPORT_SIZE, 0x8,
-    D_INPUT, (D_CONSTANT),
+  // Reserved byte
+  D_REPORT_COUNT, 0x1,
+  D_REPORT_SIZE, 0x8,
+  D_INPUT, (D_CONSTANT),
 
-    // LEDs
-    D_REPORT_COUNT, 0x5,
-    D_REPORT_SIZE, 0x1,
-    D_USAGE_PAGE, D_PAGE_LEDS,
-    D_USAGE_MINIMUM, 0x1,
-    D_USAGE_MAXIMUM, 0x5,
-    D_OUTPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),
-    // Pad LEDs up to a byte
-    D_REPORT_COUNT, 0x1,
-    D_REPORT_SIZE, 0x3,
-    D_OUTPUT, (D_CONSTANT),
+  // LEDs
+  D_REPORT_COUNT, 0x5,
+  D_REPORT_SIZE, 0x1,
+  D_USAGE_PAGE, D_PAGE_LEDS,
+  D_USAGE_MINIMUM, 0x1,
+  D_USAGE_MAXIMUM, 0x5,
+  D_OUTPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
+  // Pad LEDs up to a byte
+  D_REPORT_COUNT, 0x1,
+  D_REPORT_SIZE, 0x3,
+  D_OUTPUT, (D_CONSTANT),
 
-    // Non-modifiers
-    D_REPORT_COUNT, 0x6,
-    D_REPORT_SIZE, 0x8,
-    D_LOGICAL_MINIMUM, 0x0,
-    D_LOGICAL_MAXIMUM, 0xff,
-    D_USAGE_PAGE, D_PAGE_KEYBOARD,
-    D_USAGE_MINIMUM, 0x0,
-    D_USAGE_MAXIMUM, 0xff,
-    D_INPUT, (D_DATA|D_ARRAY|D_ABSOLUTE),
-    D_END_COLLECTION
+  // Non-modifiers
+  D_REPORT_COUNT, 0x6,
+  D_REPORT_SIZE, 0x8,
+  D_LOGICAL_MINIMUM, 0x0,
+  D_LOGICAL_MAXIMUM, 0xff,
+  D_USAGE_PAGE, D_PAGE_KEYBOARD,
+  D_USAGE_MINIMUM, 0x0,
+  D_USAGE_MAXIMUM, 0xff,
+  D_INPUT, (D_DATA | D_ARRAY | D_ABSOLUTE),
+  D_END_COLLECTION
 };
 
 BootKeyboard_::BootKeyboard_(void) : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1), leds(0) {
-    epType[0] = EP_TYPE_INTERRUPT_IN;
+  epType[0] = EP_TYPE_INTERRUPT_IN;
 }
 
 int BootKeyboard_::getInterface(uint8_t* interfaceCount) {
-    *interfaceCount += 1; // uses 1
-    HIDDescriptor hidInterface = {
-        D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_BOOT_INTERFACE, HID_PROTOCOL_KEYBOARD),
-        D_HIDREPORT(sizeof(_hidReportDescriptorKeyboard)),
-        D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
-    };
-    return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
+  *interfaceCount += 1; // uses 1
+  HIDDescriptor hidInterface = {
+    D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_BOOT_INTERFACE, HID_PROTOCOL_KEYBOARD),
+    D_HIDREPORT(sizeof(_hidReportDescriptorKeyboard)),
+    D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
+  };
+  return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
 int BootKeyboard_::getDescriptor(USBSetup& setup) {
-    // Check if this is a HID Class Descriptor request
-    if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
-        return 0;
-    }
-    if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) {
-        return 0;
-    }
+  // Check if this is a HID Class Descriptor request
+  if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
+    return 0;
+  }
+  if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) {
+    return 0;
+  }
 
-    // In a HID Class Descriptor wIndex cointains the interface number
-    if (setup.wIndex != pluggedInterface) {
-        return 0;
-    }
+  // In a HID Class Descriptor wIndex cointains the interface number
+  if (setup.wIndex != pluggedInterface) {
+    return 0;
+  }
 
-    // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-    // due to the USB specs, but Windows and Linux just assumes its in report mode.
-    protocol = default_protocol;
+  // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+  // due to the USB specs, but Windows and Linux just assumes its in report mode.
+  protocol = default_protocol;
 
-    return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorKeyboard, sizeof(_hidReportDescriptorKeyboard));
+  return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorKeyboard, sizeof(_hidReportDescriptorKeyboard));
 }
 
 
 void BootKeyboard_::begin(void) {
-    PluggableUSB().plug(this);
+  PluggableUSB().plug(this);
 
-    // Force API to send a clean report.
-    // This is important for and HID bridge where the receiver stays on,
-    // while the sender is resetted.
-    releaseAll();
-    sendReport();
+  // Force API to send a clean report.
+  // This is important for and HID bridge where the receiver stays on,
+  // while the sender is resetted.
+  releaseAll();
+  sendReport();
 }
 
 
 void BootKeyboard_::end(void) {
-    releaseAll();
-    sendReport();
+  releaseAll();
+  sendReport();
 }
 
 
 
 bool BootKeyboard_::setup(USBSetup& setup) {
-    if (pluggedInterface != setup.wIndex) {
-        return false;
-    }
-
-    uint8_t request = setup.bRequest;
-    uint8_t requestType = setup.bmRequestType;
-
-    if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE) {
-        if (request == HID_GET_REPORT) {
-            // TODO: HID_GetReport();
-            return true;
-        }
-        if (request == HID_GET_PROTOCOL) {
-            // TODO improve
-#ifdef __AVR__
-            UEDATX = protocol;
-#endif
-#ifdef ARDUINO_ARCH_SAM
-            USBDevice.armSend(0, &protocol, 1);
-#endif
-            return true;
-        }
-        if (request == HID_GET_IDLE) {
-            // TODO improve
-#ifdef __AVR__
-            UEDATX = idle;
-#endif
-#ifdef ARDUINO_ARCH_SAM
-            USBDevice.armSend(0, &idle, 1);
-#endif
-            return true;
-        }
-    }
-
-    if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
-        if (request == HID_SET_PROTOCOL) {
-            protocol = setup.wValueL;
-            return true;
-        }
-        if (request == HID_SET_IDLE) {
-            // We currently ignore SET_IDLE, because we don't really do anything with it, and implementing
-            // it causes issues on OSX, such as key chatter. Other operating systems do not suffer if we
-            // force this to zero, either.
-#if 0
-            idle = setup.wValueL;
-#else
-            idle = 0;
-#endif
-            return true;
-        }
-        if (request == HID_SET_REPORT) {
-            // Check if data has the correct length afterwards
-            int length = setup.wLength;
-
-            if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
-                if (length == sizeof(leds)) {
-                    USB_RecvControl(&leds, length);
-                    return true;
-                }
-            }
-
-            // Input (set HID report)
-            else if (setup.wValueH == HID_REPORT_TYPE_INPUT) {
-                if (length == sizeof(_keyReport)) {
-                    USB_RecvControl(&_keyReport, length);
-                    return true;
-                }
-            }
-        }
-    }
-
+  if (pluggedInterface != setup.wIndex) {
     return false;
+  }
+
+  uint8_t request = setup.bRequest;
+  uint8_t requestType = setup.bmRequestType;
+
+  if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE) {
+    if (request == HID_GET_REPORT) {
+      // TODO: HID_GetReport();
+      return true;
+    }
+    if (request == HID_GET_PROTOCOL) {
+      // TODO improve
+#ifdef __AVR__
+      UEDATX = protocol;
+#endif
+#ifdef ARDUINO_ARCH_SAM
+      USBDevice.armSend(0, &protocol, 1);
+#endif
+      return true;
+    }
+    if (request == HID_GET_IDLE) {
+      // TODO improve
+#ifdef __AVR__
+      UEDATX = idle;
+#endif
+#ifdef ARDUINO_ARCH_SAM
+      USBDevice.armSend(0, &idle, 1);
+#endif
+      return true;
+    }
+  }
+
+  if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
+    if (request == HID_SET_PROTOCOL) {
+      protocol = setup.wValueL;
+      return true;
+    }
+    if (request == HID_SET_IDLE) {
+      // We currently ignore SET_IDLE, because we don't really do anything with it, and implementing
+      // it causes issues on OSX, such as key chatter. Other operating systems do not suffer if we
+      // force this to zero, either.
+#if 0
+      idle = setup.wValueL;
+#else
+      idle = 0;
+#endif
+      return true;
+    }
+    if (request == HID_SET_REPORT) {
+      // Check if data has the correct length afterwards
+      int length = setup.wLength;
+
+      if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
+        if (length == sizeof(leds)) {
+          USB_RecvControl(&leds, length);
+          return true;
+        }
+      }
+
+      // Input (set HID report)
+      else if (setup.wValueH == HID_REPORT_TYPE_INPUT) {
+        if (length == sizeof(_keyReport)) {
+          USB_RecvControl(&_keyReport, length);
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
 }
 
 uint8_t BootKeyboard_::getLeds(void) {
-    return leds;
+  return leds;
 }
 
 uint8_t BootKeyboard_::getProtocol(void) {
-    return protocol;
+  return protocol;
 }
 
 void BootKeyboard_::setProtocol(uint8_t protocol) {
-    this->protocol = protocol;
+  this->protocol = protocol;
 }
 
 int BootKeyboard_::sendReport(void) {
-    if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
-        // if the two reports are different, send a report
-        int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
-        HIDReportObserver::observeReport(HID_REPORTID_KEYBOARD, &_keyReport, sizeof(_keyReport), returnCode);
-        memcpy(&_lastKeyReport, &_keyReport, sizeof(_keyReport));
-        return returnCode;
-    }
-    return -1;
+  if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
+    // if the two reports are different, send a report
+    int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
+    HIDReportObserver::observeReport(HID_REPORTID_KEYBOARD, &_keyReport, sizeof(_keyReport), returnCode);
+    memcpy(&_lastKeyReport, &_keyReport, sizeof(_keyReport));
+    return returnCode;
+  }
+  return -1;
 }
 
 // press() adds the specified key (printing, non-printing, or modifier)
@@ -232,35 +232,35 @@ int BootKeyboard_::sendReport(void) {
 
 
 size_t BootKeyboard_::press(uint8_t k) {
-    uint8_t done = 0;
+  uint8_t done = 0;
 
-    if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
-        // it's a modifier key
-        _keyReport.modifiers |= (0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER));
-    } else {
-        // it's some other key:
-        // Add k to the key report only if it's not already present
-        // and if there is an empty slot.
-        for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-            if (_keyReport.keycodes[i] != k) { // is k already in list?
-                if (0 == _keyReport.keycodes[i]) { // have we found an empty slot?
-                    _keyReport.keycodes[i] = k;
-                    done = 1;
-                    break;
-                }
-            } else {
-                done = 1;
-                break;
-            }
+  if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
+    // it's a modifier key
+    _keyReport.modifiers |= (0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER));
+  } else {
+    // it's some other key:
+    // Add k to the key report only if it's not already present
+    // and if there is an empty slot.
+    for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
+      if (_keyReport.keycodes[i] != k) { // is k already in list?
+        if (0 == _keyReport.keycodes[i]) { // have we found an empty slot?
+          _keyReport.keycodes[i] = k;
+          done = 1;
+          break;
         }
-        // use separate variable to check if slot was found
-        // for style reasons - we do not know how the compiler
-        // handles the for() index when it leaves the loop
-        if (0 == done) {
-            return 0;
-        }
+      } else {
+        done = 1;
+        break;
+      }
     }
-    return 1;
+    // use separate variable to check if slot was found
+    // for style reasons - we do not know how the compiler
+    // handles the for() index when it leaves the loop
+    if (0 == done) {
+      return 0;
+    }
+  }
+  return 1;
 }
 
 
@@ -269,43 +269,43 @@ size_t BootKeyboard_::press(uint8_t k) {
 // it shouldn't be repeated any more.
 
 size_t BootKeyboard_::release(uint8_t k) {
-    if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
-        // it's a modifier key
-        _keyReport.modifiers = _keyReport.modifiers & (~(0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER)));
-    } else {
-        // it's some other key:
-        // Test the key report to see if k is present.  Clear it if it exists.
-        // Check all positions in case the key is present more than once (which it shouldn't be)
-        for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-            if (_keyReport.keycodes[i] == k) {
-                _keyReport.keycodes[i] = 0;
-            }
-        }
-
-        // rearrange the keys list so that the free (= 0x00) are at the
-        // end of the keys list - some implementations stop for keys at the
-        // first occurence of an 0x00 in the keys list
-        // so (0x00)(0x01)(0x00)(0x03)(0x02)(0x00) becomes
-        //    (0x03)(0x02)(0x01)(0x00)(0x00)(0x00)
-        uint8_t current = 0, nextpos = 0;
-
-        while (current < sizeof(_keyReport.keycodes)) {
-            if (_keyReport.keycodes[current]) {
-                uint8_t tmp = _keyReport.keycodes[nextpos];
-                _keyReport.keycodes[nextpos] = _keyReport.keycodes[current];
-                _keyReport.keycodes[current] = tmp;
-                ++nextpos;
-            }
-            ++current;
-        }
+  if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
+    // it's a modifier key
+    _keyReport.modifiers = _keyReport.modifiers & (~(0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER)));
+  } else {
+    // it's some other key:
+    // Test the key report to see if k is present.  Clear it if it exists.
+    // Check all positions in case the key is present more than once (which it shouldn't be)
+    for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
+      if (_keyReport.keycodes[i] == k) {
+        _keyReport.keycodes[i] = 0;
+      }
     }
 
-    return 1;
+    // rearrange the keys list so that the free (= 0x00) are at the
+    // end of the keys list - some implementations stop for keys at the
+    // first occurence of an 0x00 in the keys list
+    // so (0x00)(0x01)(0x00)(0x03)(0x02)(0x00) becomes
+    //    (0x03)(0x02)(0x01)(0x00)(0x00)(0x00)
+    uint8_t current = 0, nextpos = 0;
+
+    while (current < sizeof(_keyReport.keycodes)) {
+      if (_keyReport.keycodes[current]) {
+        uint8_t tmp = _keyReport.keycodes[nextpos];
+        _keyReport.keycodes[nextpos] = _keyReport.keycodes[current];
+        _keyReport.keycodes[current] = tmp;
+        ++nextpos;
+      }
+      ++current;
+    }
+  }
+
+  return 1;
 }
 
 
 void BootKeyboard_::releaseAll(void) {
-    memset(&_keyReport.bytes, 0x00, sizeof(_keyReport.bytes));
+  memset(&_keyReport.bytes, 0x00, sizeof(_keyReport.bytes));
 }
 
 
@@ -313,24 +313,24 @@ void BootKeyboard_::releaseAll(void) {
  * Returns false in all other cases
  * */
 boolean BootKeyboard_::isKeyPressed(uint8_t k) {
-    for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-        if (_keyReport.keycodes[i] == k) {
-            return true;
-        }
+  for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
+    if (_keyReport.keycodes[i] == k) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 /* Returns true if the non-modifer key passed in was sent during the previous key report
  * Returns false in all other cases
  * */
 boolean BootKeyboard_::wasKeyPressed(uint8_t k) {
-    for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-        if (_lastKeyReport.keycodes[i] == k) {
-            return true;
-        }
+  for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
+    if (_lastKeyReport.keycodes[i] == k) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 
@@ -339,36 +339,36 @@ boolean BootKeyboard_::wasKeyPressed(uint8_t k) {
  * Returns false in all other cases
  * */
 boolean BootKeyboard_::isModifierActive(uint8_t k) {
-    if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
-        k = k - HID_KEYBOARD_FIRST_MODIFIER;
-        return !!(_keyReport.modifiers & (1 << k));
-    }
-    return false;
+  if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    return !!(_keyReport.modifiers & (1 << k));
+  }
+  return false;
 }
 
 /* Returns true if the modifer key passed in was being sent during the previous key report
  * Returns false in all other cases
  * */
 boolean BootKeyboard_::wasModifierActive(uint8_t k) {
-    if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
-        k = k - HID_KEYBOARD_FIRST_MODIFIER;
-        return !!(_lastKeyReport.modifiers & (1 << k));
-    }
-    return false;
+  if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    return !!(_lastKeyReport.modifiers & (1 << k));
+  }
+  return false;
 }
 
 /* Returns true if any modifier key will be sent during this key report
  * Returns false in all other cases
  * */
 boolean BootKeyboard_::isAnyModifierActive() {
-    return _keyReport.modifiers > 0;
+  return _keyReport.modifiers > 0;
 }
 
 /* Returns true if any modifier key was being sent during the previous key report
  * Returns false in all other cases
  * */
 boolean BootKeyboard_::wasAnyModifierActive() {
-    return _lastKeyReport.modifiers > 0;
+  return _lastKeyReport.modifiers > 0;
 }
 
 BootKeyboard_ BootKeyboard;

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -73,7 +73,7 @@ static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
   D_END_COLLECTION
 };
 
-BootKeyboard_::BootKeyboard_(void) : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1), leds(0) {
+BootKeyboard_::BootKeyboard_() : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1), leds(0) {
   epType[0] = EP_TYPE_INTERRUPT_IN;
 }
 
@@ -109,7 +109,7 @@ int BootKeyboard_::getDescriptor(USBSetup& setup) {
 }
 
 
-void BootKeyboard_::begin(void) {
+void BootKeyboard_::begin() {
   PluggableUSB().plug(this);
 
   // Force API to send a clean report.
@@ -120,7 +120,7 @@ void BootKeyboard_::begin(void) {
 }
 
 
-void BootKeyboard_::end(void) {
+void BootKeyboard_::end() {
   releaseAll();
   sendReport();
 }
@@ -202,11 +202,11 @@ bool BootKeyboard_::setup(USBSetup& setup) {
   return false;
 }
 
-uint8_t BootKeyboard_::getLeds(void) {
+uint8_t BootKeyboard_::getLeds() {
   return leds;
 }
 
-uint8_t BootKeyboard_::getProtocol(void) {
+uint8_t BootKeyboard_::getProtocol() {
   return protocol;
 }
 
@@ -214,7 +214,7 @@ void BootKeyboard_::setProtocol(uint8_t protocol) {
   this->protocol = protocol;
 }
 
-int BootKeyboard_::sendReport(void) {
+int BootKeyboard_::sendReport() {
   if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
     // if the two reports are different, send a report
     int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
@@ -304,7 +304,7 @@ size_t BootKeyboard_::release(uint8_t k) {
 }
 
 
-void BootKeyboard_::releaseAll(void) {
+void BootKeyboard_::releaseAll() {
   memset(&_keyReport.bytes, 0x00, sizeof(_keyReport.bytes));
 }
 

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include "HIDReportObserver.h"
 
 // See Appendix B of USB HID spec
-static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
+static const uint8_t boot_keyboard_hid_descriptor_[] PROGMEM = {
   //  Keyboard
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,
   D_USAGE, D_USAGE_KEYBOARD,
@@ -81,7 +81,7 @@ int BootKeyboard_::getInterface(uint8_t* interfaceCount) {
   *interfaceCount += 1; // uses 1
   HIDDescriptor hidInterface = {
     D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_BOOT_INTERFACE, HID_PROTOCOL_KEYBOARD),
-    D_HIDREPORT(sizeof(_hidReportDescriptorKeyboard)),
+    D_HIDREPORT(sizeof(boot_keyboard_hid_descriptor_)),
     D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
   };
   return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
@@ -105,7 +105,7 @@ int BootKeyboard_::getDescriptor(USBSetup& setup) {
   // due to the USB specs, but Windows and Linux just assumes its in report mode.
   protocol = default_protocol;
 
-  return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorKeyboard, sizeof(_hidReportDescriptorKeyboard));
+  return USB_SendControl(TRANSFER_PGM, boot_keyboard_hid_descriptor_, sizeof(boot_keyboard_hid_descriptor_));
 }
 
 
@@ -191,8 +191,8 @@ bool BootKeyboard_::setup(USBSetup& setup) {
 
       // Input (set HID report)
       else if (setup.wValueH == HID_REPORT_TYPE_INPUT) {
-        if (length == sizeof(_keyReport)) {
-          USB_RecvControl(&_keyReport, length);
+        if (length == sizeof(key_report_)) {
+          USB_RecvControl(&key_report_, length);
           return true;
         }
       }
@@ -215,11 +215,11 @@ void BootKeyboard_::setProtocol(uint8_t protocol) {
 }
 
 int BootKeyboard_::sendReport() {
-  if (memcmp(&_lastKeyReport, &_keyReport, sizeof(_keyReport))) {
+  if (memcmp(&last_key_report_, &key_report_, sizeof(key_report_))) {
     // if the two reports are different, send a report
-    int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
-    HIDReportObserver::observeReport(HID_REPORTID_KEYBOARD, &_keyReport, sizeof(_keyReport), returnCode);
-    memcpy(&_lastKeyReport, &_keyReport, sizeof(_keyReport));
+    int returnCode = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &key_report_, sizeof(key_report_));
+    HIDReportObserver::observeReport(HID_REPORTID_KEYBOARD, &key_report_, sizeof(key_report_), returnCode);
+    memcpy(&last_key_report_, &key_report_, sizeof(key_report_));
     return returnCode;
   }
   return -1;
@@ -236,15 +236,15 @@ size_t BootKeyboard_::press(uint8_t k) {
 
   if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
     // it's a modifier key
-    _keyReport.modifiers |= (0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER));
+    key_report_.modifiers |= (0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER));
   } else {
     // it's some other key:
     // Add k to the key report only if it's not already present
     // and if there is an empty slot.
-    for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-      if (_keyReport.keycodes[i] != k) { // is k already in list?
-        if (0 == _keyReport.keycodes[i]) { // have we found an empty slot?
-          _keyReport.keycodes[i] = k;
+    for (uint8_t i = 0; i < sizeof(key_report_.keycodes); i++) {
+      if (key_report_.keycodes[i] != k) { // is k already in list?
+        if (0 == key_report_.keycodes[i]) { // have we found an empty slot?
+          key_report_.keycodes[i] = k;
           done = 1;
           break;
         }
@@ -271,14 +271,14 @@ size_t BootKeyboard_::press(uint8_t k) {
 size_t BootKeyboard_::release(uint8_t k) {
   if ((k >= HID_KEYBOARD_FIRST_MODIFIER) && (k <= HID_KEYBOARD_LAST_MODIFIER)) {
     // it's a modifier key
-    _keyReport.modifiers = _keyReport.modifiers & (~(0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER)));
+    key_report_.modifiers = key_report_.modifiers & (~(0x01 << (k - HID_KEYBOARD_FIRST_MODIFIER)));
   } else {
     // it's some other key:
     // Test the key report to see if k is present.  Clear it if it exists.
     // Check all positions in case the key is present more than once (which it shouldn't be)
-    for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-      if (_keyReport.keycodes[i] == k) {
-        _keyReport.keycodes[i] = 0;
+    for (uint8_t i = 0; i < sizeof(key_report_.keycodes); i++) {
+      if (key_report_.keycodes[i] == k) {
+        key_report_.keycodes[i] = 0;
       }
     }
 
@@ -289,11 +289,11 @@ size_t BootKeyboard_::release(uint8_t k) {
     //    (0x03)(0x02)(0x01)(0x00)(0x00)(0x00)
     uint8_t current = 0, nextpos = 0;
 
-    while (current < sizeof(_keyReport.keycodes)) {
-      if (_keyReport.keycodes[current]) {
-        uint8_t tmp = _keyReport.keycodes[nextpos];
-        _keyReport.keycodes[nextpos] = _keyReport.keycodes[current];
-        _keyReport.keycodes[current] = tmp;
+    while (current < sizeof(key_report_.keycodes)) {
+      if (key_report_.keycodes[current]) {
+        uint8_t tmp = key_report_.keycodes[nextpos];
+        key_report_.keycodes[nextpos] = key_report_.keycodes[current];
+        key_report_.keycodes[current] = tmp;
         ++nextpos;
       }
       ++current;
@@ -305,7 +305,7 @@ size_t BootKeyboard_::release(uint8_t k) {
 
 
 void BootKeyboard_::releaseAll() {
-  memset(&_keyReport.bytes, 0x00, sizeof(_keyReport.bytes));
+  memset(&key_report_.bytes, 0x00, sizeof(key_report_.bytes));
 }
 
 
@@ -313,8 +313,8 @@ void BootKeyboard_::releaseAll() {
  * Returns false in all other cases
  * */
 bool BootKeyboard_::isKeyPressed(uint8_t k) {
-  for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-    if (_keyReport.keycodes[i] == k) {
+  for (uint8_t i = 0; i < sizeof(key_report_.keycodes); i++) {
+    if (key_report_.keycodes[i] == k) {
       return true;
     }
   }
@@ -325,8 +325,8 @@ bool BootKeyboard_::isKeyPressed(uint8_t k) {
  * Returns false in all other cases
  * */
 bool BootKeyboard_::wasKeyPressed(uint8_t k) {
-  for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++) {
-    if (_lastKeyReport.keycodes[i] == k) {
+  for (uint8_t i = 0; i < sizeof(key_report_.keycodes); i++) {
+    if (last_key_report_.keycodes[i] == k) {
       return true;
     }
   }
@@ -341,7 +341,7 @@ bool BootKeyboard_::wasKeyPressed(uint8_t k) {
 bool BootKeyboard_::isModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
-    return !!(_keyReport.modifiers & (1 << k));
+    return !!(key_report_.modifiers & (1 << k));
   }
   return false;
 }
@@ -352,7 +352,7 @@ bool BootKeyboard_::isModifierActive(uint8_t k) {
 bool BootKeyboard_::wasModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
-    return !!(_lastKeyReport.modifiers & (1 << k));
+    return !!(last_key_report_.modifiers & (1 << k));
   }
   return false;
 }
@@ -361,14 +361,14 @@ bool BootKeyboard_::wasModifierActive(uint8_t k) {
  * Returns false in all other cases
  * */
 bool BootKeyboard_::isAnyModifierActive() {
-  return _keyReport.modifiers > 0;
+  return key_report_.modifiers > 0;
 }
 
 /* Returns true if any modifier key was being sent during the previous key report
  * Returns false in all other cases
  * */
 bool BootKeyboard_::wasAnyModifierActive() {
-  return _lastKeyReport.modifiers > 0;
+  return last_key_report_.modifiers > 0;
 }
 
 BootKeyboard_ BootKeyboard;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -54,12 +54,12 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   int sendReport();
 
-  boolean isModifierActive(uint8_t k);
-  boolean wasModifierActive(uint8_t k);
-  boolean isAnyModifierActive();
-  boolean wasAnyModifierActive();
-  boolean isKeyPressed(uint8_t k);
-  boolean wasKeyPressed(uint8_t k);
+  bool isModifierActive(uint8_t k);
+  bool wasModifierActive(uint8_t k);
+  bool isAnyModifierActive();
+  bool wasAnyModifierActive();
+  bool isKeyPressed(uint8_t k);
+  bool wasKeyPressed(uint8_t k);
 
   uint8_t getLeds();
   uint8_t getProtocol();

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -33,52 +33,52 @@ THE SOFTWARE.
 #include "HIDAliases.h"
 
 typedef union {
-    // Low level key report: up to 6 keys and shift, ctrl etc at once
-    struct {
-        uint8_t modifiers;
-        uint8_t reserved;
-        uint8_t keycodes[6];
-    };
-    uint8_t bytes[8];
+  // Low level key report: up to 6 keys and shift, ctrl etc at once
+  struct {
+    uint8_t modifiers;
+    uint8_t reserved;
+    uint8_t keycodes[6];
+  };
+  uint8_t bytes[8];
 } HID_BootKeyboardReport_Data_t;
 
 
 class BootKeyboard_ : public PluggableUSBModule {
-  public:
-    BootKeyboard_(void);
-    size_t press(uint8_t);
-    void begin(void);
-    void end(void);
-    size_t release(uint8_t);
-    void releaseAll(void);
+ public:
+  BootKeyboard_(void);
+  size_t press(uint8_t);
+  void begin(void);
+  void end(void);
+  size_t release(uint8_t);
+  void releaseAll(void);
 
-    int sendReport(void);
+  int sendReport(void);
 
-    boolean isModifierActive(uint8_t k);
-    boolean wasModifierActive(uint8_t k);
-    boolean isAnyModifierActive();
-    boolean wasAnyModifierActive();
-    boolean isKeyPressed(uint8_t k);
-    boolean wasKeyPressed(uint8_t k);
+  boolean isModifierActive(uint8_t k);
+  boolean wasModifierActive(uint8_t k);
+  boolean isAnyModifierActive();
+  boolean wasAnyModifierActive();
+  boolean isKeyPressed(uint8_t k);
+  boolean wasKeyPressed(uint8_t k);
 
-    uint8_t getLeds(void);
-    uint8_t getProtocol(void);
-    void setProtocol(uint8_t protocol);
+  uint8_t getLeds(void);
+  uint8_t getProtocol(void);
+  void setProtocol(uint8_t protocol);
 
-    uint8_t default_protocol = HID_REPORT_PROTOCOL;
+  uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
-  protected:
-    HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;
+ protected:
+  HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;
 
-    // Implementation of the PUSBListNode
-    int getInterface(uint8_t* interfaceCount);
-    int getDescriptor(USBSetup& setup);
-    bool setup(USBSetup& setup);
+  // Implementation of the PUSBListNode
+  int getInterface(uint8_t* interfaceCount);
+  int getDescriptor(USBSetup& setup);
+  bool setup(USBSetup& setup);
 
-    EPTYPE_DESCRIPTOR_SIZE epType[1];
-    uint8_t protocol;
-    uint8_t idle;
+  EPTYPE_DESCRIPTOR_SIZE epType[1];
+  uint8_t protocol;
+  uint8_t idle;
 
-    uint8_t leds;
+  uint8_t leds;
 };
 extern BootKeyboard_ BootKeyboard;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -45,14 +45,14 @@ typedef union {
 
 class BootKeyboard_ : public PluggableUSBModule {
  public:
-  BootKeyboard_(void);
+  BootKeyboard_();
   size_t press(uint8_t);
-  void begin(void);
-  void end(void);
+  void begin();
+  void end();
   size_t release(uint8_t);
-  void releaseAll(void);
+  void releaseAll();
 
-  int sendReport(void);
+  int sendReport();
 
   boolean isModifierActive(uint8_t k);
   boolean wasModifierActive(uint8_t k);
@@ -61,8 +61,8 @@ class BootKeyboard_ : public PluggableUSBModule {
   boolean isKeyPressed(uint8_t k);
   boolean wasKeyPressed(uint8_t k);
 
-  uint8_t getLeds(void);
-  uint8_t getProtocol(void);
+  uint8_t getLeds();
+  uint8_t getProtocol();
   void setProtocol(uint8_t protocol);
 
   uint8_t default_protocol = HID_REPORT_PROTOCOL;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -46,10 +46,10 @@ typedef union {
 class BootKeyboard_ : public PluggableUSBModule {
  public:
   BootKeyboard_();
-  size_t press(uint8_t);
+  size_t press(uint8_t k);
   void begin();
   void end();
-  size_t release(uint8_t);
+  size_t release(uint8_t k);
   void releaseAll();
 
   int sendReport();

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -68,7 +68,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
  protected:
-  HID_BootKeyboardReport_Data_t _keyReport, _lastKeyReport;
+  HID_BootKeyboardReport_Data_t key_report_, last_key_report_;
 
   // Implementation of the PUSBListNode
   int getInterface(uint8_t* interfaceCount);

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -68,7 +68,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t default_protocol = HID_REPORT_PROTOCOL;
 
  protected:
-  HID_BootKeyboardReport_Data_t key_report_, last_key_report_;
+  HID_BootKeyboardReport_Data_t report_, last_report_;
 
   // Implementation of the PUSBListNode
   int getInterface(uint8_t* interfaceCount);

--- a/src/DescriptorPrimitives.h
+++ b/src/DescriptorPrimitives.h
@@ -60,45 +60,44 @@ THE SOFTWARE.
 // The bits that make up inputs, outputs and features
 
 // Bit 0
-#define D_DATA         0b00000000
-#define D_CONSTANT     0b00000001
+#define D_DATA              0b00000000
+#define D_CONSTANT          0b00000001
 // Bit 1
-#define D_ARRAY        0b00000000
-#define D_VARIABLE     0b00000010
+#define D_ARRAY             0b00000000
+#define D_VARIABLE          0b00000010
 // Bit 2
-#define D_ABSOLUTE     0b00000000
-#define D_RELATIVE     0b00000100
+#define D_ABSOLUTE          0b00000000
+#define D_RELATIVE          0b00000100
 // Bit 3
-#define D_NO_WRAP      0b00000000
-#define D_WRAP         0b00001000
+#define D_NO_WRAP           0b00000000
+#define D_WRAP              0b00001000
 // Bit 4
-#define D_LINEAR       0b00000000
-#define D_NON_LINEAR   0b00010000
+#define D_LINEAR            0b00000000
+#define D_NON_LINEAR        0b00010000
 // Bit 5
-#define D_PREFERRED_STATE 0b00000000
-#define D_NO_PREFERRED    0b00100000
+#define D_PREFERRED_STATE   0b00000000
+#define D_NO_PREFERRED      0b00100000
 // Bit 6
-#define D_NO_NULL_POSITION      0b00000000
-#define D_NULL_STATE            0b01000000
+#define D_NO_NULL_POSITION  0b00000000
+#define D_NULL_STATE        0b01000000
 // Bit 7
-#define D_NON_VOLATILE    0b00000000
-#define D_VOLATILE        0b01000000
-
+#define D_NON_VOLATILE      0b00000000
+#define D_VOLATILE          0b01000000
 // Bit 8
-#define D_BIT_FIELD        0b00000000
-#define D_BUFFERED_BYTES   0b10000000
+#define D_BIT_FIELD         0b00000000
+#define D_BUFFERED_BYTES    0b10000000
 
 
 
 // Collection types
 
 
-#define D_PHYSICAL    0x00  // (group of axes)
-#define D_APPLICATION  0x01  // (mouse, keyboard)
-#define D_LOGICAL      0x02// (interrelated data)
-#define D_REPORT       0x03
-#define D_NAMED_ARRAY  0x04
-#define D_USAGE_SWITCH 0x05
+#define D_PHYSICAL        0x00  // (group of axes)
+#define D_APPLICATION     0x01  // (mouse, keyboard)
+#define D_LOGICAL         0x02  // (interrelated data)
+#define D_REPORT          0x03
+#define D_NAMED_ARRAY     0x04
+#define D_USAGE_SWITCH    0x05
 #define D_USAGE_MODIFIER  0x06
 // 0x07-0x7f - Reserved
 // 0x80-0xff - Vendor define

--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -65,38 +65,38 @@ THE SOFTWARE.
   D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),
 
 typedef union {
-    // Absolute mouse report: 8 buttons, 2 absolute axis, wheel
-    struct {
-        uint8_t buttons;
-        uint16_t xAxis;
-        uint16_t yAxis;
-        int8_t wheel;
-    };
+  // Absolute mouse report: 8 buttons, 2 absolute axis, wheel
+  struct {
+    uint8_t buttons;
+    uint16_t xAxis;
+    uint16_t yAxis;
+    int8_t wheel;
+  };
 } HID_MouseAbsoluteReport_Data_t;
 
 class AbsoluteMouseAPI {
-  public:
-    inline AbsoluteMouseAPI(void);
-    inline void begin(void);
-    inline void end(void);
+ public:
+  inline AbsoluteMouseAPI(void);
+  inline void begin(void);
+  inline void end(void);
 
-    inline void click(uint8_t b = MOUSE_LEFT);
-    inline void moveTo(uint16_t x, uint16_t y, signed char wheel = 0);
-    inline void move(int x, int y, signed char wheel = 0);
-    inline void press(uint8_t b = MOUSE_LEFT);
-    inline void release(uint8_t b = MOUSE_LEFT);
-    inline bool isPressed(uint8_t b = MOUSE_LEFT);
+  inline void click(uint8_t b = MOUSE_LEFT);
+  inline void moveTo(uint16_t x, uint16_t y, signed char wheel = 0);
+  inline void move(int x, int y, signed char wheel = 0);
+  inline void press(uint8_t b = MOUSE_LEFT);
+  inline void release(uint8_t b = MOUSE_LEFT);
+  inline bool isPressed(uint8_t b = MOUSE_LEFT);
 
-    // Sending is public in the base class for advanced users.
-    virtual void sendReport(void* data, int length) {}
+  // Sending is public in the base class for advanced users.
+  virtual void sendReport(void* data, int length) {}
 
-  protected:
-    uint16_t xAxis;
-    uint16_t yAxis;
-    uint8_t _buttons;
+ protected:
+  uint16_t xAxis;
+  uint16_t yAxis;
+  uint8_t _buttons;
 
-    inline void buttons(uint8_t b);
-    inline int16_t qadd16(int16_t base, int16_t increment);
+  inline void buttons(uint8_t b);
+  inline int16_t qadd16(int16_t base, int16_t increment);
 };
 
 #include "AbsoluteMouseAPI.hpp"

--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -76,9 +76,9 @@ typedef union {
 
 class AbsoluteMouseAPI {
  public:
-  inline AbsoluteMouseAPI(void);
-  inline void begin(void);
-  inline void end(void);
+  inline AbsoluteMouseAPI();
+  inline void begin();
+  inline void end();
 
   inline void click(uint8_t b = MOUSE_LEFT);
   inline void moveTo(uint16_t x, uint16_t y, signed char wheel = 0);

--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -33,35 +33,35 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 
-#define DESCRIPTOR_ABS_MOUSE_BUTTONS  					  \
-  /* 8 Buttons */							  \
-  D_USAGE_PAGE, D_PAGE_BUTTON,             /* USAGE_PAGE (Button) */	  \
+#define DESCRIPTOR_ABS_MOUSE_BUTTONS \
+  /* 8 Buttons */                                                         \
+  D_USAGE_PAGE, D_PAGE_BUTTON,             /* USAGE_PAGE (Button) */      \
   D_USAGE_MINIMUM, 0x01,                   /* USAGE_MINIMUM (Button 1) */ \
   D_USAGE_MAXIMUM, 0x08,                   /* USAGE_MAXIMUM (Button 8) */ \
-  D_LOGICAL_MINIMUM, 0x00,                 /* LOGICAL_MINIMUM (0) */	  \
-  D_LOGICAL_MAXIMUM, 0x01,                 /* LOGICAL_MAXIMUM (1) */	  \
-  D_REPORT_COUNT, 0x08,                    /* REPORT_COUNT (8) */	  \
-  D_REPORT_SIZE, 0x01,                     /* REPORT_SIZE (1) */	  \
+  D_LOGICAL_MINIMUM, 0x00,                 /* LOGICAL_MINIMUM (0) */      \
+  D_LOGICAL_MAXIMUM, 0x01,                 /* LOGICAL_MAXIMUM (1) */      \
+  D_REPORT_COUNT, 0x08,                    /* REPORT_COUNT (8) */         \
+  D_REPORT_SIZE, 0x01,                     /* REPORT_SIZE (1) */          \
   D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),
 
 # define DESCRIPTOR_ABS_MOUSE_XY \
-  /* X, Y */ 									 \
+  /* X, Y */                                                                     \
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,       /* USAGE_PAGE (Generic Desktop) */ \
-  D_USAGE, 0x30,                      	      /* USAGE (X) */			 \
-  D_USAGE, 0x31,                              /* USAGE (Y) */			 \
-  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x00, /* Logical Minimum (0) */ 	 \
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7f, /* Logical Maximum (32767) */	 \
-  D_REPORT_SIZE, 0x10,			      /* Report Size (16), */		 \
-  D_REPORT_COUNT, 0x02,		 	      /* Report Count (2), */		 \
+  D_USAGE, 0x30,                              /* USAGE (X) */                    \
+  D_USAGE, 0x31,                              /* USAGE (Y) */                    \
+  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x00, /* Logical Minimum (0) */          \
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7f, /* Logical Maximum (32767) */      \
+  D_REPORT_SIZE, 0x10,                        /* Report Size (16), */            \
+  D_REPORT_COUNT, 0x02,                       /* Report Count (2), */            \
   D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),    /* Input (Data, Variable, Absolute) */
 
 #define DESCRIPTOR_ABS_MOUSE_WHEEL \
-  /* Wheel */									\
-  D_USAGE, 0x38,                      	    /*     USAGE (Wheel) */		\
-  D_LOGICAL_MINIMUM, 0x81,                  /*     LOGICAL_MINIMUM (-127) */	\
-  D_LOGICAL_MAXIMUM, 0x7f,                  /*     LOGICAL_MAXIMUM (127) */	\
-  D_REPORT_SIZE, 0x08,                      /*     REPORT_SIZE (8) */		\
-  D_REPORT_COUNT, 0x01,                     /*     REPORT_COUNT (1) */		\
+  /* Wheel */                                                               \
+  D_USAGE, 0x38,                            /* USAGE (Wheel) */             \
+  D_LOGICAL_MINIMUM, 0x81,                  /* LOGICAL_MINIMUM (-127) */    \
+  D_LOGICAL_MAXIMUM, 0x7f,                  /* LOGICAL_MAXIMUM (127) */     \
+  D_REPORT_SIZE, 0x08,                      /* REPORT_SIZE (8) */           \
+  D_REPORT_COUNT, 0x01,                     /* REPORT_COUNT (1) */          \
   D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),
 
 typedef union {

--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -33,15 +33,15 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 
-#define DESCRIPTOR_ABS_MOUSE_BUTTONS  					 \
-  /* 8 Buttons */							 \
-  D_USAGE_PAGE, D_PAGE_BUTTON,        /*     USAGE_PAGE (Button) */	 \
-  D_USAGE_MINIMUM, 0x01,              /*     USAGE_MINIMUM (Button 1) */ \
-  D_USAGE_MAXIMUM, 0x08,              /*     USAGE_MAXIMUM (Button 8) */ \
-  D_LOGICAL_MINIMUM, 0x00,            /*     LOGICAL_MINIMUM (0) */	 \
-  D_LOGICAL_MAXIMUM, 0x01,            /*     LOGICAL_MAXIMUM (1) */	 \
-  D_REPORT_COUNT, 0x08,               /*     REPORT_COUNT (8) */	 \
-  D_REPORT_SIZE, 0x01,                /*     REPORT_SIZE (1) */	         \
+#define DESCRIPTOR_ABS_MOUSE_BUTTONS  					  \
+  /* 8 Buttons */							  \
+  D_USAGE_PAGE, D_PAGE_BUTTON,             /* USAGE_PAGE (Button) */	  \
+  D_USAGE_MINIMUM, 0x01,                   /* USAGE_MINIMUM (Button 1) */ \
+  D_USAGE_MAXIMUM, 0x08,                   /* USAGE_MAXIMUM (Button 8) */ \
+  D_LOGICAL_MINIMUM, 0x00,                 /* LOGICAL_MINIMUM (0) */	  \
+  D_LOGICAL_MAXIMUM, 0x01,                 /* LOGICAL_MAXIMUM (1) */	  \
+  D_REPORT_COUNT, 0x08,                    /* REPORT_COUNT (8) */	  \
+  D_REPORT_SIZE, 0x01,                     /* REPORT_SIZE (1) */	  \
   D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),
 
 # define DESCRIPTOR_ABS_MOUSE_XY \

--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -81,8 +81,8 @@ class AbsoluteMouseAPI {
   inline void end();
 
   inline void click(uint8_t b = MOUSE_LEFT);
-  inline void moveTo(uint16_t x, uint16_t y, signed char wheel = 0);
-  inline void move(int x, int y, signed char wheel = 0);
+  inline void moveTo(uint16_t x, uint16_t y, int8_t wheel = 0);
+  inline void move(int x, int y, int8_t wheel = 0);
   inline void press(uint8_t b = MOUSE_LEFT);
   inline void release(uint8_t b = MOUSE_LEFT);
   inline bool isPressed(uint8_t b = MOUSE_LEFT);

--- a/src/DeviceAPIs/AbsoluteMouseAPI.h
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.h
@@ -91,9 +91,9 @@ class AbsoluteMouseAPI {
   virtual void sendReport(void* data, int length) {}
 
  protected:
-  uint16_t xAxis;
-  uint16_t yAxis;
-  uint8_t _buttons;
+  uint16_t x_axis_;
+  uint16_t y_axis_;
+  uint8_t buttons_;
 
   inline void buttons(uint8_t b);
   inline int16_t qadd16(int16_t base, int16_t increment);

--- a/src/DeviceAPIs/AbsoluteMouseAPI.hpp
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.hpp
@@ -25,13 +25,13 @@ THE SOFTWARE.
 
 #pragma once
 
-AbsoluteMouseAPI::AbsoluteMouseAPI(): xAxis(0), yAxis(0), _buttons(0) { // Empty
+AbsoluteMouseAPI::AbsoluteMouseAPI(): x_axis_(0), y_axis_(0), buttons_(0) { // Empty
 }
 
 void AbsoluteMouseAPI::buttons(uint8_t b) {
-  if (b != _buttons) {
-    _buttons = b;
-    moveTo(xAxis, yAxis, 0);
+  if (b != buttons_) {
+    buttons_ = b;
+    moveTo(x_axis_, y_axis_, 0);
   }
 }
 
@@ -59,22 +59,22 @@ void AbsoluteMouseAPI::begin() {
 }
 
 void AbsoluteMouseAPI::end() {
-  _buttons = 0;
-  moveTo(xAxis, yAxis, 0);
+  buttons_ = 0;
+  moveTo(x_axis_, y_axis_, 0);
 }
 
 void AbsoluteMouseAPI::click(uint8_t b) {
-  _buttons = b;
-  moveTo(xAxis, yAxis, 0);
-  _buttons = 0;
-  moveTo(xAxis, yAxis, 0);
+  buttons_ = b;
+  moveTo(x_axis_, y_axis_, 0);
+  buttons_ = 0;
+  moveTo(x_axis_, y_axis_, 0);
 }
 
 void AbsoluteMouseAPI::moveTo(uint16_t x, uint16_t y, signed char wheel) {
-  xAxis = x;
-  yAxis = y;
+  x_axis_ = x;
+  y_axis_ = y;
   HID_MouseAbsoluteReport_Data_t report;
-  report.buttons = _buttons;
+  report.buttons = buttons_;
   report.xAxis = x;
   report.yAxis = y;
   report.wheel = wheel;
@@ -82,22 +82,22 @@ void AbsoluteMouseAPI::moveTo(uint16_t x, uint16_t y, signed char wheel) {
 }
 
 void AbsoluteMouseAPI::move(int x, int y, signed char wheel) {
-  moveTo(qadd16(xAxis, x), qadd16(yAxis, y), wheel);
+  moveTo(qadd16(x_axis_, x), qadd16(y_axis_, y), wheel);
 }
 
 void AbsoluteMouseAPI::press(uint8_t b) {
   // press LEFT by default
-  buttons(_buttons | b);
+  buttons(buttons_ | b);
 }
 
 void AbsoluteMouseAPI::release(uint8_t b) {
   // release LEFT by default
-  buttons(_buttons & ~b);
+  buttons(buttons_ & ~b);
 }
 
 bool AbsoluteMouseAPI::isPressed(uint8_t b) {
   // check LEFT by default
-  if ((b & _buttons) > 0)
+  if ((b & buttons_) > 0)
     return true;
   return false;
 }

--- a/src/DeviceAPIs/AbsoluteMouseAPI.hpp
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.hpp
@@ -25,8 +25,8 @@ THE SOFTWARE.
 
 #pragma once
 
-AbsoluteMouseAPI::AbsoluteMouseAPI(): x_axis_(0), y_axis_(0), buttons_(0) { // Empty
-}
+AbsoluteMouseAPI::AbsoluteMouseAPI()
+    : x_axis_(0), y_axis_(0), buttons_(0) {}
 
 void AbsoluteMouseAPI::buttons(uint8_t b) {
   if (b != buttons_) {

--- a/src/DeviceAPIs/AbsoluteMouseAPI.hpp
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.hpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 #pragma once
 
-AbsoluteMouseAPI::AbsoluteMouseAPI(void): xAxis(0), yAxis(0), _buttons(0) { // Empty
+AbsoluteMouseAPI::AbsoluteMouseAPI(): xAxis(0), yAxis(0), _buttons(0) { // Empty
 }
 
 void AbsoluteMouseAPI::buttons(uint8_t b) {
@@ -53,12 +53,12 @@ int16_t AbsoluteMouseAPI::qadd16(int16_t base, int16_t increment) {
   return base;
 }
 
-void AbsoluteMouseAPI::begin(void) {
+void AbsoluteMouseAPI::begin() {
   // release all buttons
   end();
 }
 
-void AbsoluteMouseAPI::end(void) {
+void AbsoluteMouseAPI::end() {
   _buttons = 0;
   moveTo(xAxis, yAxis, 0);
 }

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -170,7 +170,7 @@ bool HID_::setup(USBSetup& setup) {
   return false;
 }
 
-HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
+HID_::HID_() : PluggableUSBModule(1, 1, epType),
   rootNode(NULL), descriptorSize(0),
   protocol(HID_REPORT_PROTOCOL), idle(1) {
   setReportData.reportId = 0;
@@ -179,7 +179,7 @@ HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
   PluggableUSB().plug(this);
 }
 
-int HID_::begin(void) {
+int HID_::begin() {
   return 0;
 }
 

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -24,80 +24,80 @@
 #if defined(USBCON)
 
 HID_& HID() {
-    static HID_ obj;
-    return obj;
+  static HID_ obj;
+  return obj;
 }
 
 int HID_::getInterface(uint8_t* interfaceCount) {
-    *interfaceCount += 1; // uses 1
-    HIDDescriptor hidInterface = {
-        D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
-        D_HIDREPORT(descriptorSize),
-        D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
-    };
-    return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
+  *interfaceCount += 1; // uses 1
+  HIDDescriptor hidInterface = {
+    D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
+    D_HIDREPORT(descriptorSize),
+    D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
+  };
+  return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
 int HID_::getDescriptor(USBSetup& setup) {
-    // Check if this is a HID Class Descriptor request
-    if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
-        return 0;
-    }
-    if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) {
-        return 0;
-    }
+  // Check if this is a HID Class Descriptor request
+  if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
+    return 0;
+  }
+  if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) {
+    return 0;
+  }
 
-    // In a HID Class Descriptor wIndex cointains the interface number
-    if (setup.wIndex != pluggedInterface) {
-        return 0;
-    }
+  // In a HID Class Descriptor wIndex cointains the interface number
+  if (setup.wIndex != pluggedInterface) {
+    return 0;
+  }
 
-    int total = 0;
-    HIDSubDescriptor* node;
-    USB_PackMessages(true);
-    for (node = rootNode; node; node = node->next) {
-        int res = USB_SendControl(TRANSFER_PGM, node->data, node->length);
-        if (res == -1)
-            return -1;
-        total += res;
-    }
+  int total = 0;
+  HIDSubDescriptor* node;
+  USB_PackMessages(true);
+  for (node = rootNode; node; node = node->next) {
+    int res = USB_SendControl(TRANSFER_PGM, node->data, node->length);
+    if (res == -1)
+      return -1;
+    total += res;
+  }
 
-    // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-    // due to the USB specs, but Windows and Linux just assumes its in report mode.
-    protocol = HID_REPORT_PROTOCOL;
+  // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+  // due to the USB specs, but Windows and Linux just assumes its in report mode.
+  protocol = HID_REPORT_PROTOCOL;
 
-    USB_PackMessages(false);
-    return total;
+  USB_PackMessages(false);
+  return total;
 }
 
 __attribute__((weak))
 uint8_t HID_::getShortName(char *name) {
-    name[0] = 'k';
-    name[1] = 'b';
-    name[2] = 'i';
-    name[3] = 'o';
-    name[4] = '0';
-    name[5] = '1';
-    return 6;
+  name[0] = 'k';
+  name[1] = 'b';
+  name[2] = 'i';
+  name[3] = 'o';
+  name[4] = '0';
+  name[5] = '1';
+  return 6;
 }
 
 void HID_::AppendDescriptor(HIDSubDescriptor *node) {
-    if (!rootNode) {
-        rootNode = node;
-    } else {
-        HIDSubDescriptor *current = rootNode;
-        while (current->next) {
-            current = current->next;
-        }
-        current->next = node;
+  if (!rootNode) {
+    rootNode = node;
+  } else {
+    HIDSubDescriptor *current = rootNode;
+    while (current->next) {
+      current = current->next;
     }
-    descriptorSize += node->length;
+    current->next = node;
+  }
+  descriptorSize += node->length;
 }
 
 int HID_::SendReport(uint8_t id, const void* data, int len) {
-    auto result = SendReport_(id, data, len);
-    HIDReportObserver::observeReport(id, data, len, result);
-    return result;
+  auto result = SendReport_(id, data, len);
+  HIDReportObserver::observeReport(id, data, len, result);
+  return result;
 }
 
 int HID_::SendReport_(uint8_t id, const void* data, int len) {
@@ -109,78 +109,78 @@ int HID_::SendReport_(uint8_t id, const void* data, int len) {
    * costs RAM, which is something scarce on AVR. So on that platform, we opt to
    * send the id and the report separately instead. */
 #ifdef ARDUINO_ARCH_SAMD
-    uint8_t p[64];
-    p[0] = id;
-    memcpy(&p[1], data, len);
-    return USB_Send(pluggedEndpoint, p, len+1);
+  uint8_t p[64];
+  p[0] = id;
+  memcpy(&p[1], data, len);
+  return USB_Send(pluggedEndpoint, p, len + 1);
 #else
-    auto ret = USB_Send(pluggedEndpoint, &id, 1);
-    if (ret < 0) return ret;
-    auto ret2 = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
-    if (ret2 < 0) return ret2;
-    return ret + ret2;
+  auto ret = USB_Send(pluggedEndpoint, &id, 1);
+  if (ret < 0) return ret;
+  auto ret2 = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
+  if (ret2 < 0) return ret2;
+  return ret + ret2;
 #endif
 }
 
 bool HID_::setup(USBSetup& setup) {
-    if (pluggedInterface != setup.wIndex) {
-        return false;
-    }
-
-    uint8_t request = setup.bRequest;
-    uint8_t requestType = setup.bmRequestType;
-
-    if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE) {
-        if (request == HID_GET_REPORT) {
-            // TODO: HID_GetReport();
-            return true;
-        }
-        if (request == HID_GET_PROTOCOL) {
-            // TODO: Send8(protocol);
-            return true;
-        }
-        if (request == HID_GET_IDLE) {
-            // TODO: Send8(idle);
-        }
-    }
-
-    if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
-        if (request == HID_SET_PROTOCOL) {
-            // The USB Host tells us if we are in boot or report mode.
-            // This only works with a real boot compatible device.
-            protocol = setup.wValueL;
-            return true;
-        }
-        if (request == HID_SET_IDLE) {
-            idle = setup.wValueL;
-            return true;
-        }
-        if (request == HID_SET_REPORT) {
-            uint16_t length = setup.wLength;
-
-            if (length == sizeof(setReportData)) {
-                USB_RecvControl(&setReportData, length);
-            } else if (length == sizeof(setReportData.leds)) {
-                USB_RecvControl(&setReportData.leds, length);
-                setReportData.reportId = 0;
-            }
-        }
-    }
-
+  if (pluggedInterface != setup.wIndex) {
     return false;
+  }
+
+  uint8_t request = setup.bRequest;
+  uint8_t requestType = setup.bmRequestType;
+
+  if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE) {
+    if (request == HID_GET_REPORT) {
+      // TODO: HID_GetReport();
+      return true;
+    }
+    if (request == HID_GET_PROTOCOL) {
+      // TODO: Send8(protocol);
+      return true;
+    }
+    if (request == HID_GET_IDLE) {
+      // TODO: Send8(idle);
+    }
+  }
+
+  if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
+    if (request == HID_SET_PROTOCOL) {
+      // The USB Host tells us if we are in boot or report mode.
+      // This only works with a real boot compatible device.
+      protocol = setup.wValueL;
+      return true;
+    }
+    if (request == HID_SET_IDLE) {
+      idle = setup.wValueL;
+      return true;
+    }
+    if (request == HID_SET_REPORT) {
+      uint16_t length = setup.wLength;
+
+      if (length == sizeof(setReportData)) {
+        USB_RecvControl(&setReportData, length);
+      } else if (length == sizeof(setReportData.leds)) {
+        USB_RecvControl(&setReportData.leds, length);
+        setReportData.reportId = 0;
+      }
+    }
+  }
+
+  return false;
 }
 
 HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
-    rootNode(NULL), descriptorSize(0),
-    protocol(HID_REPORT_PROTOCOL), idle(1) {
-    setReportData.reportId = 0;
-    setReportData.leds = 0;
-    epType[0] = EP_TYPE_INTERRUPT_IN;
-    PluggableUSB().plug(this);
+  rootNode(NULL), descriptorSize(0),
+  protocol(HID_REPORT_PROTOCOL), idle(1) {
+  setReportData.reportId = 0;
+  setReportData.leds = 0;
+  epType[0] = EP_TYPE_INTERRUPT_IN;
+  PluggableUSB().plug(this);
 }
 
 int HID_::begin(void) {
-    return 0;
+  return 0;
 }
 
 #endif /* if defined(USBCON) */

--- a/src/HID.h
+++ b/src/HID.h
@@ -89,11 +89,11 @@ class HIDSubDescriptor {
 class HID_ : public PluggableUSBModule {
  public:
 
-  HID_(void);
-  int begin(void);
+  HID_();
+  int begin();
   int SendReport(uint8_t id, const void* data, int len);
   void AppendDescriptor(HIDSubDescriptor* node);
-  uint8_t getLEDs(void) {
+  uint8_t getLEDs() {
     return setReportData.leds;
   };
 

--- a/src/HID.h
+++ b/src/HID.h
@@ -60,63 +60,63 @@
 #define HID_REPORT_TYPE_FEATURE 3
 
 typedef struct {
-    uint8_t len;      // 9
-    uint8_t dtype;    // 0x21
-    uint8_t addr;
-    uint8_t versionL; // 0x101
-    uint8_t versionH; // 0x101
-    uint8_t country;
-    uint8_t desctype; // 0x22 report
-    uint8_t descLenL;
-    uint8_t descLenH;
+  uint8_t len;      // 9
+  uint8_t dtype;    // 0x21
+  uint8_t addr;
+  uint8_t versionL; // 0x101
+  uint8_t versionH; // 0x101
+  uint8_t country;
+  uint8_t desctype; // 0x22 report
+  uint8_t descLenL;
+  uint8_t descLenH;
 } HIDDescDescriptor;
 
 typedef struct {
-    InterfaceDescriptor hid;
-    HIDDescDescriptor   desc;
-    EndpointDescriptor  in;
+  InterfaceDescriptor hid;
+  HIDDescDescriptor   desc;
+  EndpointDescriptor  in;
 } HIDDescriptor;
 
 class HIDSubDescriptor {
-  public:
-    HIDSubDescriptor *next = NULL;
-    HIDSubDescriptor(const void *d, const uint16_t l) : data(d), length(l) { }
+ public:
+  HIDSubDescriptor *next = NULL;
+  HIDSubDescriptor(const void *d, const uint16_t l) : data(d), length(l) { }
 
-    const void* data;
-    const uint16_t length;
+  const void* data;
+  const uint16_t length;
 };
 
 class HID_ : public PluggableUSBModule {
-  public:
+ public:
 
-    HID_(void);
-    int begin(void);
-    int SendReport(uint8_t id, const void* data, int len);
-    void AppendDescriptor(HIDSubDescriptor* node);
-    uint8_t getLEDs(void) {
-        return setReportData.leds;
-    };
+  HID_(void);
+  int begin(void);
+  int SendReport(uint8_t id, const void* data, int len);
+  void AppendDescriptor(HIDSubDescriptor* node);
+  uint8_t getLEDs(void) {
+    return setReportData.leds;
+  };
 
-  protected:
-    // Implementation of the PluggableUSBModule
-    int getInterface(uint8_t* interfaceCount);
-    int getDescriptor(USBSetup& setup);
-    bool setup(USBSetup& setup);
-    uint8_t getShortName(char* name);
+ protected:
+  // Implementation of the PluggableUSBModule
+  int getInterface(uint8_t* interfaceCount);
+  int getDescriptor(USBSetup& setup);
+  bool setup(USBSetup& setup);
+  uint8_t getShortName(char* name);
 
-    int SendReport_(uint8_t id, const void* data, int len);
-  private:
-    EPTYPE_DESCRIPTOR_SIZE epType[1];
+  int SendReport_(uint8_t id, const void* data, int len);
+ private:
+  EPTYPE_DESCRIPTOR_SIZE epType[1];
 
-    HIDSubDescriptor* rootNode;
-    uint16_t descriptorSize;
+  HIDSubDescriptor* rootNode;
+  uint16_t descriptorSize;
 
-    uint8_t protocol;
-    uint8_t idle;
-    struct {
-        uint8_t reportId;
-        uint8_t leds;
-    } setReportData;
+  uint8_t protocol;
+  uint8_t idle;
+  struct {
+    uint8_t reportId;
+    uint8_t leds;
+  } setReportData;
 };
 
 // Replacement for global singleton.

--- a/src/HIDReportObserver.h
+++ b/src/HIDReportObserver.h
@@ -26,29 +26,30 @@ THE SOFTWARE.
 
 #include <stdint.h>
 
-class HIDReportObserver
-{
-   public:
+class HIDReportObserver {
+ public:
 
-    typedef void(*SendReportHook)(uint8_t id, const void* data, 
-                                  int len, int result);
-    
-    static void observeReport(uint8_t id, const void* data, 
-                                  int len, int result) {
-       if(send_report_hook_) {
-          (*send_report_hook_)(id, data, len, result);
-       }
+  typedef void(*SendReportHook)(uint8_t id, const void* data,
+                                int len, int result);
+
+  static void observeReport(uint8_t id, const void* data,
+                            int len, int result) {
+    if (send_report_hook_) {
+      (*send_report_hook_)(id, data, len, result);
     }
-      
-    static SendReportHook currentHook() { return send_report_hook_; }
-    
-    static SendReportHook resetHook(SendReportHook new_hook) {
-       auto previous_hook = send_report_hook_;
-       send_report_hook_ = new_hook; 
-       return previous_hook;
-   }
-      
-   private:
-      
-      static SendReportHook send_report_hook_;
+  }
+
+  static SendReportHook currentHook() {
+    return send_report_hook_;
+  }
+
+  static SendReportHook resetHook(SendReportHook new_hook) {
+    auto previous_hook = send_report_hook_;
+    send_report_hook_ = new_hook;
+    return previous_hook;
+  }
+
+ private:
+
+  static SendReportHook send_report_hook_;
 };

--- a/src/HIDTables.h
+++ b/src/HIDTables.h
@@ -38,7 +38,7 @@ THE SOFTWARE.
 // Not every HID usage listed in this file is currently supported by Arduino
 // In particular, any System Control or Consumer Control entry that doesn't
 // have a comment indicating that it's "HID type OSC" may require additional
-// code in the Arduino core to work, although // some keycodes with usage 
+// code in the Arduino core to work, although // some keycodes with usage
 // type RTC (Re-Trigger Control) and OOC (On/Off Control) are also functional.
 //
 // Non-working usages are listed here in the interest of not having to manually

--- a/src/LEDs.h
+++ b/src/LEDs.h
@@ -27,12 +27,12 @@ THE SOFTWARE.
 
 // Keyboard Leds
 enum KeyboardLeds : uint8_t {
-    LED_NUM_LOCK            = (1 << 0),
-    LED_CAPS_LOCK           = (1 << 1),
-    LED_SCROLL_LOCK         = (1 << 2),
-    LED_COMPOSE                     = (1 << 3),
-    LED_KANA                        = (1 << 4),
-    LED_POWER                       = (1 << 5),
-    LED_SHIFT                       = (1 << 6),
-    LED_DO_NOT_DISTURB      = (1 << 7),
+  LED_NUM_LOCK            = (1 << 0),
+  LED_CAPS_LOCK           = (1 << 1),
+  LED_SCROLL_LOCK         = (1 << 2),
+  LED_COMPOSE                     = (1 << 3),
+  LED_KANA                        = (1 << 4),
+  LED_POWER                       = (1 << 5),
+  LED_SHIFT                       = (1 << 6),
+  LED_DO_NOT_DISTURB      = (1 << 7),
 };

--- a/src/LEDs.h
+++ b/src/LEDs.h
@@ -27,12 +27,12 @@ THE SOFTWARE.
 
 // Keyboard Leds
 enum KeyboardLeds : uint8_t {
-  LED_NUM_LOCK            = (1 << 0),
-  LED_CAPS_LOCK           = (1 << 1),
-  LED_SCROLL_LOCK         = (1 << 2),
-  LED_COMPOSE                     = (1 << 3),
-  LED_KANA                        = (1 << 4),
-  LED_POWER                       = (1 << 5),
-  LED_SHIFT                       = (1 << 6),
-  LED_DO_NOT_DISTURB      = (1 << 7),
+  LED_NUM_LOCK       = (1 << 0),
+  LED_CAPS_LOCK      = (1 << 1),
+  LED_SCROLL_LOCK    = (1 << 2),
+  LED_COMPOSE        = (1 << 3),
+  LED_KANA           = (1 << 4),
+  LED_POWER          = (1 << 5),
+  LED_SHIFT          = (1 << 6),
+  LED_DO_NOT_DISTURB = (1 << 7),
 };

--- a/src/MouseButtons.h
+++ b/src/MouseButtons.h
@@ -25,11 +25,11 @@ THE SOFTWARE.
 
 #pragma once
 
-#define MOUSE_LEFT		(1 << 0)
-#define MOUSE_RIGHT		(1 << 1)
+#define MOUSE_LEFT	(1 << 0)
+#define MOUSE_RIGHT	(1 << 1)
 #define MOUSE_MIDDLE	(1 << 2)
-#define MOUSE_PREV		(1 << 3)
-#define MOUSE_NEXT		(1 << 4)
+#define MOUSE_PREV	(1 << 3)
+#define MOUSE_NEXT	(1 << 4)
 // actually this mouse report has 8 buttons (for smaller descriptor)
 // but the last 3 wont do anything from what I tested
 #define MOUSE_ALL (MOUSE_LEFT | MOUSE_RIGHT | MOUSE_MIDDLE | MOUSE_PREV | MOUSE_NEXT)

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -41,7 +41,8 @@ static const uint8_t absolute_mouse_hid_descriptor_[] PROGMEM = {
 };
 
 AbsoluteMouse_::AbsoluteMouse_() {
-  static HIDSubDescriptor node(absolute_mouse_hid_descriptor_, sizeof(absolute_mouse_hid_descriptor_));
+  static HIDSubDescriptor node(absolute_mouse_hid_descriptor_,
+                               sizeof(absolute_mouse_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "AbsoluteMouse.h"
 #include "DescriptorPrimitives.h"
 
-static const uint8_t _hidMultiReportDescriptorAbsoluteMouse[] PROGMEM = {
+static const uint8_t absolute_mouse_hid_descriptor_[] PROGMEM = {
   /*  Mouse absolute */
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)	  54 */
   D_USAGE, D_USAGE_MOUSE,                      	/* USAGE (Mouse) */
@@ -41,7 +41,7 @@ static const uint8_t _hidMultiReportDescriptorAbsoluteMouse[] PROGMEM = {
 };
 
 AbsoluteMouse_::AbsoluteMouse_() {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorAbsoluteMouse, sizeof(_hidMultiReportDescriptorAbsoluteMouse));
+  static HIDSubDescriptor node(absolute_mouse_hid_descriptor_, sizeof(absolute_mouse_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -40,7 +40,7 @@ static const uint8_t _hidMultiReportDescriptorAbsoluteMouse[] PROGMEM = {
   D_END_COLLECTION 				 /* End */
 };
 
-AbsoluteMouse_::AbsoluteMouse_(void) {
+AbsoluteMouse_::AbsoluteMouse_() {
   static HIDSubDescriptor node(_hidMultiReportDescriptorAbsoluteMouse, sizeof(_hidMultiReportDescriptorAbsoluteMouse));
   HID().AppendDescriptor(&node);
 }

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -28,16 +28,16 @@ THE SOFTWARE.
 
 static const uint8_t absolute_mouse_hid_descriptor_[] PROGMEM = {
   /*  Mouse absolute */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)	  54 */
-  D_USAGE, D_USAGE_MOUSE,                      	/* USAGE (Mouse) */
-  D_COLLECTION, D_APPLICATION,                 	/* COLLECTION (Application) */
-  D_REPORT_ID, HID_REPORTID_MOUSE_ABSOLUTE,	/*  REPORT_ID */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)   54 */
+  D_USAGE, D_USAGE_MOUSE,                       /* USAGE (Mouse) */
+  D_COLLECTION, D_APPLICATION,                  /* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_MOUSE_ABSOLUTE,     /*  REPORT_ID */
 
   DESCRIPTOR_ABS_MOUSE_BUTTONS
   DESCRIPTOR_ABS_MOUSE_XY
   DESCRIPTOR_ABS_MOUSE_WHEEL
 
-  D_END_COLLECTION 				 /* End */
+  D_END_COLLECTION                               /* End */
 };
 
 AbsoluteMouse_::AbsoluteMouse_() {

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -27,27 +27,27 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 static const uint8_t _hidMultiReportDescriptorAbsoluteMouse[] PROGMEM = {
-    /*  Mouse absolute */
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)	  54 */
-    D_USAGE, D_USAGE_MOUSE,                      	/* USAGE (Mouse) */
-    D_COLLECTION, D_APPLICATION,                 	/* COLLECTION (Application) */
-    D_REPORT_ID, HID_REPORTID_MOUSE_ABSOLUTE,	/*  REPORT_ID */
+  /*  Mouse absolute */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)	  54 */
+  D_USAGE, D_USAGE_MOUSE,                      	/* USAGE (Mouse) */
+  D_COLLECTION, D_APPLICATION,                 	/* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_MOUSE_ABSOLUTE,	/*  REPORT_ID */
 
-    DESCRIPTOR_ABS_MOUSE_BUTTONS
-    DESCRIPTOR_ABS_MOUSE_XY
-    DESCRIPTOR_ABS_MOUSE_WHEEL
+  DESCRIPTOR_ABS_MOUSE_BUTTONS
+  DESCRIPTOR_ABS_MOUSE_XY
+  DESCRIPTOR_ABS_MOUSE_WHEEL
 
-    D_END_COLLECTION 				 /* End */
+  D_END_COLLECTION 				 /* End */
 };
 
 AbsoluteMouse_::AbsoluteMouse_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorAbsoluteMouse, sizeof(_hidMultiReportDescriptorAbsoluteMouse));
-    HID().AppendDescriptor(&node);
+  static HIDSubDescriptor node(_hidMultiReportDescriptorAbsoluteMouse, sizeof(_hidMultiReportDescriptorAbsoluteMouse));
+  HID().AppendDescriptor(&node);
 }
 
 
 void AbsoluteMouse_::sendReport(void* data, int length) {
-    HID().SendReport(HID_REPORTID_MOUSE_ABSOLUTE, data, length);
+  HID().SendReport(HID_REPORTID_MOUSE_ABSOLUTE, data, length);
 }
 
 AbsoluteMouse_ AbsoluteMouse;

--- a/src/MultiReport/AbsoluteMouse.h
+++ b/src/MultiReport/AbsoluteMouse.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 class AbsoluteMouse_ : public AbsoluteMouseAPI {
  public:
-  AbsoluteMouse_(void);
+  AbsoluteMouse_();
 
  protected:
   // Sending is public in the base class for advanced users.

--- a/src/MultiReport/AbsoluteMouse.h
+++ b/src/MultiReport/AbsoluteMouse.h
@@ -32,12 +32,12 @@ THE SOFTWARE.
 #include "../DeviceAPIs/AbsoluteMouseAPI.h"
 
 class AbsoluteMouse_ : public AbsoluteMouseAPI {
-  public:
-    AbsoluteMouse_(void);
+ public:
+  AbsoluteMouse_(void);
 
-  protected:
-    // Sending is public in the base class for advanced users.
-    virtual void sendReport(void* data, int length);
+ protected:
+  // Sending is public in the base class for advanced users.
+  virtual void sendReport(void* data, int length);
 };
 
 extern AbsoluteMouse_ AbsoluteMouse;

--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -43,17 +43,17 @@ static const uint8_t _hidMultiReportDescriptorConsumer[] PROGMEM = {
   D_END_COLLECTION /* end collection */
 };
 
-ConsumerControl_::ConsumerControl_(void) {
+ConsumerControl_::ConsumerControl_() {
   static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
   HID().AppendDescriptor(&node);
 }
 
-void ConsumerControl_::begin(void) {
+void ConsumerControl_::begin() {
   // release all buttons
   end();
 }
 
-void ConsumerControl_::end(void) {
+void ConsumerControl_::end() {
   memset(&_report, 0, sizeof(_report));
   sendReport();
 }
@@ -83,15 +83,15 @@ void ConsumerControl_::release(uint16_t m) {
   }
 }
 
-void ConsumerControl_::releaseAll(void) {
+void ConsumerControl_::releaseAll() {
   memset(&_report, 0, sizeof(_report));
 }
 
-void ConsumerControl_::sendReportUnchecked(void) {
+void ConsumerControl_::sendReportUnchecked() {
   HID().SendReport(HID_REPORTID_CONSUMERCONTROL, &_report, sizeof(_report));
 }
 
-void ConsumerControl_::sendReport(void) {
+void ConsumerControl_::sendReport() {
   // If the last report is different than the current report, then we need to send a report.
   // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
   // if sendReport is called in a tight loop.

--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -28,18 +28,18 @@ THE SOFTWARE.
 
 static const uint8_t consumer_control_hid_descriptor_[] PROGMEM = {
   /* Consumer Control (Sound/Media keys) */
-  D_USAGE_PAGE, 0x0C,				/* usage page (consumer device) */
-  D_USAGE, 0x01, 				/* usage -- consumer control */
-  D_COLLECTION, D_APPLICATION, 			/* collection (application) */
-  D_REPORT_ID, HID_REPORTID_CONSUMERCONTROL, 	/* report id */
+  D_USAGE_PAGE, 0x0C,                           /* usage page (consumer device) */
+  D_USAGE, 0x01,                                /* usage -- consumer control */
+  D_COLLECTION, D_APPLICATION,                  /* collection (application) */
+  D_REPORT_ID, HID_REPORTID_CONSUMERCONTROL,    /* report id */
   /* 4 Media Keys */
-  D_LOGICAL_MINIMUM, 0x00, 			/* logical minimum */
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x03, 	/* logical maximum (3ff) */
-  D_USAGE_MINIMUM, 0x00, 			/* usage minimum (0) */
-  D_MULTIBYTE(D_USAGE_MAXIMUM), 0xFF, 0x03, 	/* usage maximum (3ff) */
-  D_REPORT_COUNT, 0x04, 			/* report count (4) */
-  D_REPORT_SIZE, 0x10, 				/* report size (16) */
-  D_INPUT, 0x00, 				/* input */
+  D_LOGICAL_MINIMUM, 0x00,                      /* logical minimum */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x03,   /* logical maximum (3ff) */
+  D_USAGE_MINIMUM, 0x00,                        /* usage minimum (0) */
+  D_MULTIBYTE(D_USAGE_MAXIMUM), 0xFF, 0x03,     /* usage maximum (3ff) */
+  D_REPORT_COUNT, 0x04,                         /* report count (4) */
+  D_REPORT_SIZE, 0x10,                          /* report size (16) */
+  D_INPUT, 0x00,                                /* input */
   D_END_COLLECTION /* end collection */
 };
 

--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -28,23 +28,24 @@ THE SOFTWARE.
 
 static const uint8_t consumer_control_hid_descriptor_[] PROGMEM = {
   /* Consumer Control (Sound/Media keys) */
-  D_USAGE_PAGE, 0x0C,									/* usage page (consumer device) */
-  D_USAGE, 0x01, 								/* usage -- consumer control */
-  D_COLLECTION, D_APPLICATION, 								/* collection (application) */
-  D_REPORT_ID, HID_REPORTID_CONSUMERCONTROL, 		/* report id */
+  D_USAGE_PAGE, 0x0C,				/* usage page (consumer device) */
+  D_USAGE, 0x01, 				/* usage -- consumer control */
+  D_COLLECTION, D_APPLICATION, 			/* collection (application) */
+  D_REPORT_ID, HID_REPORTID_CONSUMERCONTROL, 	/* report id */
   /* 4 Media Keys */
-  D_LOGICAL_MINIMUM, 0x00, 								/* logical minimum */
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x03, 							/* logical maximum (3ff) */
-  D_USAGE_MINIMUM, 0x00, 								/* usage minimum (0) */
-  D_MULTIBYTE(D_USAGE_MAXIMUM), 0xFF, 0x03, 							/* usage maximum (3ff) */
-  D_REPORT_COUNT, 0x04, 								/* report count (4) */
-  D_REPORT_SIZE, 0x10, 								/* report size (16) */
-  D_INPUT, 0x00, 								/* input */
+  D_LOGICAL_MINIMUM, 0x00, 			/* logical minimum */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x03, 	/* logical maximum (3ff) */
+  D_USAGE_MINIMUM, 0x00, 			/* usage minimum (0) */
+  D_MULTIBYTE(D_USAGE_MAXIMUM), 0xFF, 0x03, 	/* usage maximum (3ff) */
+  D_REPORT_COUNT, 0x04, 			/* report count (4) */
+  D_REPORT_SIZE, 0x10, 				/* report size (16) */
+  D_INPUT, 0x00, 				/* input */
   D_END_COLLECTION /* end collection */
 };
 
 ConsumerControl_::ConsumerControl_() {
-  static HIDSubDescriptor node(consumer_control_hid_descriptor_, sizeof(consumer_control_hid_descriptor_));
+  static HIDSubDescriptor node(consumer_control_hid_descriptor_,
+                               sizeof(consumer_control_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 
@@ -92,9 +93,10 @@ void ConsumerControl_::sendReportUnchecked() {
 }
 
 void ConsumerControl_::sendReport() {
-  // If the last report is different than the current report, then we need to send a report.
-  // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
-  // if sendReport is called in a tight loop.
+  // If the last report is different than the current report, then we need to
+  // send a report.  We guard sendReport like this so that calling code doesn't
+  // end up spamming the host with empty reports if sendReport is called in a
+  // tight loop.
 
   // if the previous report is the same, return early without a new report.
   if (memcmp(&last_report_, &report_, sizeof(report_)) == 0)

--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -27,81 +27,81 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 static const uint8_t _hidMultiReportDescriptorConsumer[] PROGMEM = {
-    /* Consumer Control (Sound/Media keys) */
-    D_USAGE_PAGE, 0x0C,									/* usage page (consumer device) */
-    D_USAGE, 0x01, 								/* usage -- consumer control */
-    D_COLLECTION, D_APPLICATION, 								/* collection (application) */
-    D_REPORT_ID, HID_REPORTID_CONSUMERCONTROL, 		/* report id */
-    /* 4 Media Keys */
-    D_LOGICAL_MINIMUM, 0x00, 								/* logical minimum */
-    D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x03, 							/* logical maximum (3ff) */
-    D_USAGE_MINIMUM, 0x00, 								/* usage minimum (0) */
-    D_MULTIBYTE(D_USAGE_MAXIMUM), 0xFF, 0x03, 							/* usage maximum (3ff) */
-    D_REPORT_COUNT, 0x04, 								/* report count (4) */
-    D_REPORT_SIZE, 0x10, 								/* report size (16) */
-    D_INPUT, 0x00, 								/* input */
-    D_END_COLLECTION /* end collection */
+  /* Consumer Control (Sound/Media keys) */
+  D_USAGE_PAGE, 0x0C,									/* usage page (consumer device) */
+  D_USAGE, 0x01, 								/* usage -- consumer control */
+  D_COLLECTION, D_APPLICATION, 								/* collection (application) */
+  D_REPORT_ID, HID_REPORTID_CONSUMERCONTROL, 		/* report id */
+  /* 4 Media Keys */
+  D_LOGICAL_MINIMUM, 0x00, 								/* logical minimum */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x03, 							/* logical maximum (3ff) */
+  D_USAGE_MINIMUM, 0x00, 								/* usage minimum (0) */
+  D_MULTIBYTE(D_USAGE_MAXIMUM), 0xFF, 0x03, 							/* usage maximum (3ff) */
+  D_REPORT_COUNT, 0x04, 								/* report count (4) */
+  D_REPORT_SIZE, 0x10, 								/* report size (16) */
+  D_INPUT, 0x00, 								/* input */
+  D_END_COLLECTION /* end collection */
 };
 
 ConsumerControl_::ConsumerControl_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
-    HID().AppendDescriptor(&node);
+  static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
+  HID().AppendDescriptor(&node);
 }
 
 void ConsumerControl_::begin(void) {
-    // release all buttons
-    end();
+  // release all buttons
+  end();
 }
 
 void ConsumerControl_::end(void) {
-    memset(&_report, 0, sizeof(_report));
-    sendReport();
+  memset(&_report, 0, sizeof(_report));
+  sendReport();
 }
 
 void ConsumerControl_::write(uint16_t m) {
-    press(m);
-    release(m);
+  press(m);
+  release(m);
 }
 
 void ConsumerControl_::press(uint16_t m) {
-    // search for a free spot
-    for (uint8_t i = 0; i < sizeof(HID_ConsumerControlReport_Data_t) / 2; i++) {
-        if (_report.keys[i] == 0x00) {
-            _report.keys[i] = m;
-            break;
-        }
+  // search for a free spot
+  for (uint8_t i = 0; i < sizeof(HID_ConsumerControlReport_Data_t) / 2; i++) {
+    if (_report.keys[i] == 0x00) {
+      _report.keys[i] = m;
+      break;
     }
+  }
 }
 
 void ConsumerControl_::release(uint16_t m) {
-    // search and release the keypress
-    for (uint8_t i = 0; i < sizeof(HID_ConsumerControlReport_Data_t) / 2; i++) {
-        if (_report.keys[i] == m) {
-            _report.keys[i] = 0x00;
-            // no break to delete multiple keys
-        }
+  // search and release the keypress
+  for (uint8_t i = 0; i < sizeof(HID_ConsumerControlReport_Data_t) / 2; i++) {
+    if (_report.keys[i] == m) {
+      _report.keys[i] = 0x00;
+      // no break to delete multiple keys
     }
+  }
 }
 
 void ConsumerControl_::releaseAll(void) {
-    memset(&_report, 0, sizeof(_report));
+  memset(&_report, 0, sizeof(_report));
 }
 
 void ConsumerControl_::sendReportUnchecked(void) {
-    HID().SendReport(HID_REPORTID_CONSUMERCONTROL, &_report, sizeof(_report));
+  HID().SendReport(HID_REPORTID_CONSUMERCONTROL, &_report, sizeof(_report));
 }
 
 void ConsumerControl_::sendReport(void) {
-    // If the last report is different than the current report, then we need to send a report.
-    // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
-    // if sendReport is called in a tight loop.
+  // If the last report is different than the current report, then we need to send a report.
+  // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
+  // if sendReport is called in a tight loop.
 
-    // if the previous report is the same, return early without a new report.
-    if (memcmp(&_lastReport, &_report, sizeof(_report)) == 0)
-        return;
+  // if the previous report is the same, return early without a new report.
+  if (memcmp(&_lastReport, &_report, sizeof(_report)) == 0)
+    return;
 
-    sendReportUnchecked();
-    memcpy(&_lastReport, &_report, sizeof(_report));
+  sendReportUnchecked();
+  memcpy(&_lastReport, &_report, sizeof(_report));
 }
 
 ConsumerControl_ ConsumerControl;

--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "ConsumerControl.h"
 #include "DescriptorPrimitives.h"
 
-static const uint8_t _hidMultiReportDescriptorConsumer[] PROGMEM = {
+static const uint8_t consumer_control_hid_descriptor_[] PROGMEM = {
   /* Consumer Control (Sound/Media keys) */
   D_USAGE_PAGE, 0x0C,									/* usage page (consumer device) */
   D_USAGE, 0x01, 								/* usage -- consumer control */
@@ -44,7 +44,7 @@ static const uint8_t _hidMultiReportDescriptorConsumer[] PROGMEM = {
 };
 
 ConsumerControl_::ConsumerControl_() {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorConsumer, sizeof(_hidMultiReportDescriptorConsumer));
+  static HIDSubDescriptor node(consumer_control_hid_descriptor_, sizeof(consumer_control_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 
@@ -54,7 +54,7 @@ void ConsumerControl_::begin() {
 }
 
 void ConsumerControl_::end() {
-  memset(&_report, 0, sizeof(_report));
+  memset(&report_, 0, sizeof(report_));
   sendReport();
 }
 
@@ -66,8 +66,8 @@ void ConsumerControl_::write(uint16_t m) {
 void ConsumerControl_::press(uint16_t m) {
   // search for a free spot
   for (uint8_t i = 0; i < sizeof(HID_ConsumerControlReport_Data_t) / 2; i++) {
-    if (_report.keys[i] == 0x00) {
-      _report.keys[i] = m;
+    if (report_.keys[i] == 0x00) {
+      report_.keys[i] = m;
       break;
     }
   }
@@ -76,19 +76,19 @@ void ConsumerControl_::press(uint16_t m) {
 void ConsumerControl_::release(uint16_t m) {
   // search and release the keypress
   for (uint8_t i = 0; i < sizeof(HID_ConsumerControlReport_Data_t) / 2; i++) {
-    if (_report.keys[i] == m) {
-      _report.keys[i] = 0x00;
+    if (report_.keys[i] == m) {
+      report_.keys[i] = 0x00;
       // no break to delete multiple keys
     }
   }
 }
 
 void ConsumerControl_::releaseAll() {
-  memset(&_report, 0, sizeof(_report));
+  memset(&report_, 0, sizeof(report_));
 }
 
 void ConsumerControl_::sendReportUnchecked() {
-  HID().SendReport(HID_REPORTID_CONSUMERCONTROL, &_report, sizeof(_report));
+  HID().SendReport(HID_REPORTID_CONSUMERCONTROL, &report_, sizeof(report_));
 }
 
 void ConsumerControl_::sendReport() {
@@ -97,11 +97,11 @@ void ConsumerControl_::sendReport() {
   // if sendReport is called in a tight loop.
 
   // if the previous report is the same, return early without a new report.
-  if (memcmp(&_lastReport, &_report, sizeof(_report)) == 0)
+  if (memcmp(&last_report_, &report_, sizeof(report_)) == 0)
     return;
 
   sendReportUnchecked();
-  memcpy(&_lastReport, &_report, sizeof(_report));
+  memcpy(&last_report_, &report_, sizeof(report_));
 }
 
 ConsumerControl_ ConsumerControl;

--- a/src/MultiReport/ConsumerControl.h
+++ b/src/MultiReport/ConsumerControl.h
@@ -56,8 +56,8 @@ class ConsumerControl_ {
   void sendReport();
 
  protected:
-  HID_ConsumerControlReport_Data_t _report;
-  HID_ConsumerControlReport_Data_t _lastReport;
+  HID_ConsumerControlReport_Data_t report_;
+  HID_ConsumerControlReport_Data_t last_report_;
 
  private:
   void sendReportUnchecked();

--- a/src/MultiReport/ConsumerControl.h
+++ b/src/MultiReport/ConsumerControl.h
@@ -31,35 +31,35 @@ THE SOFTWARE.
 #include "HID-Settings.h"
 
 typedef union {
-    // Every usable Consumer key possible, up to 4 keys presses possible
-    uint16_t keys[4];
-    struct {
-        uint16_t key1;
-        uint16_t key2;
-        uint16_t key3;
-        uint16_t key4;
-    };
+  // Every usable Consumer key possible, up to 4 keys presses possible
+  uint16_t keys[4];
+  struct {
+    uint16_t key1;
+    uint16_t key2;
+    uint16_t key3;
+    uint16_t key4;
+  };
 } HID_ConsumerControlReport_Data_t;
 
 
 class ConsumerControl_ {
-  public:
-    ConsumerControl_(void);
-    void begin(void);
-    void end(void);
-    void write(uint16_t m);
-    void press(uint16_t m);
-    void release(uint16_t m);
-    void releaseAll(void);
+ public:
+  ConsumerControl_(void);
+  void begin(void);
+  void end(void);
+  void write(uint16_t m);
+  void press(uint16_t m);
+  void release(uint16_t m);
+  void releaseAll(void);
 
-    // Sending is public in the base class for advanced users.
-    void sendReport(void);
+  // Sending is public in the base class for advanced users.
+  void sendReport(void);
 
-  protected:
-    HID_ConsumerControlReport_Data_t _report;
-    HID_ConsumerControlReport_Data_t _lastReport;
+ protected:
+  HID_ConsumerControlReport_Data_t _report;
+  HID_ConsumerControlReport_Data_t _lastReport;
 
-  private:
-    void sendReportUnchecked(void);
+ private:
+  void sendReportUnchecked(void);
 };
 extern ConsumerControl_ ConsumerControl;

--- a/src/MultiReport/ConsumerControl.h
+++ b/src/MultiReport/ConsumerControl.h
@@ -44,22 +44,22 @@ typedef union {
 
 class ConsumerControl_ {
  public:
-  ConsumerControl_(void);
-  void begin(void);
-  void end(void);
+  ConsumerControl_();
+  void begin();
+  void end();
   void write(uint16_t m);
   void press(uint16_t m);
   void release(uint16_t m);
-  void releaseAll(void);
+  void releaseAll();
 
   // Sending is public in the base class for advanced users.
-  void sendReport(void);
+  void sendReport();
 
  protected:
   HID_ConsumerControlReport_Data_t _report;
   HID_ConsumerControlReport_Data_t _lastReport;
 
  private:
-  void sendReportUnchecked(void);
+  void sendReportUnchecked();
 };
 extern ConsumerControl_ ConsumerControl;

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -27,136 +27,136 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
-    /* Gamepad with 32 buttons and 6 axis*/
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/* USAGE_PAGE (Generic Desktop) */
-    D_USAGE, D_USAGE_JOYSTICK,							/* USAGE (Joystick) */
-    D_COLLECTION, D_APPLICATION,							/* COLLECTION (Application) */
-    D_REPORT_ID, HID_REPORTID_GAMEPAD,			/*   REPORT_ID */
-    /* 32 Buttons */
-    D_USAGE_PAGE, D_PAGE_BUTTON,							/*   USAGE_PAGE (Button) */
-    D_USAGE_MINIMUM, 0x01,							/*   USAGE_MINIMUM (Button 1) */
-    D_USAGE_MAXIMUM, 0x20,							/*   USAGE_MAXIMUM (Button 32) */
-    D_LOGICAL_MINIMUM, 0x00,							/*   _LOGICAL_MINIMUM (0) */
-    D_LOGICAL_MAXIMUM, 0x01,							/*   _LOGICAL_MAXIMUM (1) */
-    D_REPORT_SIZE, 0x01,							/*   REPORT_SIZE (1) */
-    D_REPORT_COUNT, 0x20,							/*   REPORT_COUNT (32) */
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),							/*   INPUT (Data,Var,Abs) */
-    /* 4 16bit Axis */
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/*   USAGE_PAGE (Generic Desktop) */
-    D_COLLECTION, D_PHYSICAL,							/*   COLLECTION (Physical) */
-    D_USAGE, 0x30,							/*     USAGE (X) */
-    D_USAGE, 0x31,							/*     USAGE (Y) */
-    D_USAGE, 0x33,							/*     USAGE (Rx) */
-    D_USAGE, 0x34,							/*     USAGE (Ry) */
-    D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x80,					/*     _LOGICAL_MINIMUM (-32768) */
-    D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7F,					/*     _LOGICAL_MAXIMUM (32767) */
-    D_REPORT_SIZE, 0x10,							/*     REPORT_SIZE (16) */
-    D_REPORT_COUNT, 0x04,							/*     REPORT_COUNT (4) */
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),							/*     INPUT (Data,Var,Abs) */
-    /* 2 8bit Axis */
-    D_USAGE, 0x32,							/*     USAGE (Z) */
-    D_USAGE, 0x35,							/*     USAGE (Rz) */
-    D_LOGICAL_MINIMUM, 0x80,							/*     _LOGICAL_MINIMUM (-128) */
-    D_LOGICAL_MAXIMUM, 0x7F,							/*     _LOGICAL_MAXIMUM (127) */
-    D_REPORT_SIZE, 0x08,							/*     REPORT_SIZE (8) */
-    D_REPORT_COUNT, 0x02,							/*     REPORT_COUNT (2) */
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),							/*     INPUT (Data,Var,Abs) */
-    D_END_COLLECTION,								/*   END_COLLECTION */
+  /* Gamepad with 32 buttons and 6 axis*/
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, D_USAGE_JOYSTICK,							/* USAGE (Joystick) */
+  D_COLLECTION, D_APPLICATION,							/* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_GAMEPAD,			/*   REPORT_ID */
+  /* 32 Buttons */
+  D_USAGE_PAGE, D_PAGE_BUTTON,							/*   USAGE_PAGE (Button) */
+  D_USAGE_MINIMUM, 0x01,							/*   USAGE_MINIMUM (Button 1) */
+  D_USAGE_MAXIMUM, 0x20,							/*   USAGE_MAXIMUM (Button 32) */
+  D_LOGICAL_MINIMUM, 0x00,							/*   _LOGICAL_MINIMUM (0) */
+  D_LOGICAL_MAXIMUM, 0x01,							/*   _LOGICAL_MAXIMUM (1) */
+  D_REPORT_SIZE, 0x01,							/*   REPORT_SIZE (1) */
+  D_REPORT_COUNT, 0x20,							/*   REPORT_COUNT (32) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*   INPUT (Data,Var,Abs) */
+  /* 4 16bit Axis */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/*   USAGE_PAGE (Generic Desktop) */
+  D_COLLECTION, D_PHYSICAL,							/*   COLLECTION (Physical) */
+  D_USAGE, 0x30,							/*     USAGE (X) */
+  D_USAGE, 0x31,							/*     USAGE (Y) */
+  D_USAGE, 0x33,							/*     USAGE (Rx) */
+  D_USAGE, 0x34,							/*     USAGE (Ry) */
+  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x80,					/*     _LOGICAL_MINIMUM (-32768) */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7F,					/*     _LOGICAL_MAXIMUM (32767) */
+  D_REPORT_SIZE, 0x10,							/*     REPORT_SIZE (16) */
+  D_REPORT_COUNT, 0x04,							/*     REPORT_COUNT (4) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*     INPUT (Data,Var,Abs) */
+  /* 2 8bit Axis */
+  D_USAGE, 0x32,							/*     USAGE (Z) */
+  D_USAGE, 0x35,							/*     USAGE (Rz) */
+  D_LOGICAL_MINIMUM, 0x80,							/*     _LOGICAL_MINIMUM (-128) */
+  D_LOGICAL_MAXIMUM, 0x7F,							/*     _LOGICAL_MAXIMUM (127) */
+  D_REPORT_SIZE, 0x08,							/*     REPORT_SIZE (8) */
+  D_REPORT_COUNT, 0x02,							/*     REPORT_COUNT (2) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*     INPUT (Data,Var,Abs) */
+  D_END_COLLECTION,								/*   END_COLLECTION */
 
-    /* 2 Hat Switches */
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/*   USAGE_PAGE (Generic Desktop) */
-    D_USAGE, 0x39,							/*   USAGE (Hat switch) */
-    D_USAGE, 0x39,							/*   USAGE (Hat switch) */
-    D_LOGICAL_MINIMUM, 0x01,							/*   _LOGICAL_MINIMUM (1) */
-    D_LOGICAL_MAXIMUM, 0x08,							/*   _LOGICAL_MAXIMUM (8) */
-    D_REPORT_COUNT, 0x02,							/*   REPORT_COUNT (2) */
-    D_REPORT_SIZE, 0x04,							/*   REPORT_SIZE (4) */
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),							/*   INPUT (Data,Var,Abs) */
-    D_END_COLLECTION								/* END_COLLECTION */
+  /* 2 Hat Switches */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/*   USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x39,							/*   USAGE (Hat switch) */
+  D_USAGE, 0x39,							/*   USAGE (Hat switch) */
+  D_LOGICAL_MINIMUM, 0x01,							/*   _LOGICAL_MINIMUM (1) */
+  D_LOGICAL_MAXIMUM, 0x08,							/*   _LOGICAL_MAXIMUM (8) */
+  D_REPORT_COUNT, 0x02,							/*   REPORT_COUNT (2) */
+  D_REPORT_SIZE, 0x04,							/*   REPORT_SIZE (4) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*   INPUT (Data,Var,Abs) */
+  D_END_COLLECTION								/* END_COLLECTION */
 };
 
 Gamepad_::Gamepad_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorGamepad, sizeof(_hidMultiReportDescriptorGamepad));
-    HID().AppendDescriptor(&node);
+  static HIDSubDescriptor node(_hidMultiReportDescriptorGamepad, sizeof(_hidMultiReportDescriptorGamepad));
+  HID().AppendDescriptor(&node);
 }
 
 
 void Gamepad_::begin(void) {
-    // release all buttons
-    end();
+  // release all buttons
+  end();
 }
 
 void Gamepad_::end(void) {
-    memset(&_report, 0x00, sizeof(_report));
-    sendReport(&_report, sizeof(_report));
+  memset(&_report, 0x00, sizeof(_report));
+  sendReport(&_report, sizeof(_report));
 }
 
 void Gamepad_::write(void) {
-    sendReport(&_report, sizeof(_report));
+  sendReport(&_report, sizeof(_report));
 }
 
 
 void Gamepad_::press(uint8_t b) {
-    _report.buttons |= (uint32_t)1 << (b - 1);
+  _report.buttons |= (uint32_t)1 << (b - 1);
 }
 
 
 void Gamepad_::release(uint8_t b) {
-    _report.buttons &= ~((uint32_t)1 << (b - 1));
+  _report.buttons &= ~((uint32_t)1 << (b - 1));
 }
 
 
 void Gamepad_::releaseAll(void) {
-    memset(&_report, 0x00, sizeof(_report));
+  memset(&_report, 0x00, sizeof(_report));
 }
 
 void Gamepad_::buttons(uint32_t b) {
-    _report.buttons = b;
+  _report.buttons = b;
 }
 
 
 void Gamepad_::xAxis(int16_t a) {
-    _report.xAxis = a;
+  _report.xAxis = a;
 }
 
 
 void Gamepad_::yAxis(int16_t a) {
-    _report.yAxis = a;
+  _report.yAxis = a;
 }
 
 
 void Gamepad_::zAxis(int8_t a) {
-    _report.zAxis = a;
+  _report.zAxis = a;
 }
 
 
 void Gamepad_::rxAxis(int16_t a) {
-    _report.rxAxis = a;
+  _report.rxAxis = a;
 }
 
 
 void Gamepad_::ryAxis(int16_t a) {
-    _report.ryAxis = a;
+  _report.ryAxis = a;
 }
 
 
 void Gamepad_::rzAxis(int8_t a) {
-    _report.rzAxis = a;
+  _report.rzAxis = a;
 }
 
 
 void Gamepad_::dPad1(int8_t d) {
-    _report.dPad1 = d;
+  _report.dPad1 = d;
 }
 
 
 void Gamepad_::dPad2(int8_t d) {
-    _report.dPad2 = d;
+  _report.dPad2 = d;
 }
 
 
 void Gamepad_::sendReport(void* data, int length) {
-    HID().SendReport(HID_REPORTID_GAMEPAD, data, length);
+  HID().SendReport(HID_REPORTID_GAMEPAD, data, length);
 }
 
 Gamepad_ Gamepad;

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -28,58 +28,57 @@ THE SOFTWARE.
 
 static const uint8_t gamepad_hid_descriptor_[] PROGMEM = {
   /* Gamepad with 32 buttons and 6 axis*/
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/* USAGE_PAGE (Generic Desktop) */
-  D_USAGE, D_USAGE_JOYSTICK,							/* USAGE (Joystick) */
-  D_COLLECTION, D_APPLICATION,							/* COLLECTION (Application) */
-  D_REPORT_ID, HID_REPORTID_GAMEPAD,			/*   REPORT_ID */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, D_USAGE_JOYSTICK,			/* USAGE (Joystick) */
+  D_COLLECTION, D_APPLICATION,			/* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_GAMEPAD,		/* REPORT_ID */
   /* 32 Buttons */
-  D_USAGE_PAGE, D_PAGE_BUTTON,							/*   USAGE_PAGE (Button) */
-  D_USAGE_MINIMUM, 0x01,							/*   USAGE_MINIMUM (Button 1) */
-  D_USAGE_MAXIMUM, 0x20,							/*   USAGE_MAXIMUM (Button 32) */
-  D_LOGICAL_MINIMUM, 0x00,							/*   _LOGICAL_MINIMUM (0) */
-  D_LOGICAL_MAXIMUM, 0x01,							/*   _LOGICAL_MAXIMUM (1) */
-  D_REPORT_SIZE, 0x01,							/*   REPORT_SIZE (1) */
-  D_REPORT_COUNT, 0x20,							/*   REPORT_COUNT (32) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*   INPUT (Data,Var,Abs) */
+  D_USAGE_PAGE, D_PAGE_BUTTON,			/* USAGE_PAGE (Button) */
+  D_USAGE_MINIMUM, 0x01,			/* USAGE_MINIMUM (Button 1) */
+  D_USAGE_MAXIMUM, 0x20,			/* USAGE_MAXIMUM (Button 32) */
+  D_LOGICAL_MINIMUM, 0x00,			/* LOGICAL_MINIMUM (0) */
+  D_LOGICAL_MAXIMUM, 0x01,			/* LOGICAL_MAXIMUM (1) */
+  D_REPORT_SIZE, 0x01,				/* REPORT_SIZE (1) */
+  D_REPORT_COUNT, 0x20,				/* REPORT_COUNT (32) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
   /* 4 16bit Axis */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/*   USAGE_PAGE (Generic Desktop) */
-  D_COLLECTION, D_PHYSICAL,							/*   COLLECTION (Physical) */
-  D_USAGE, 0x30,							/*     USAGE (X) */
-  D_USAGE, 0x31,							/*     USAGE (Y) */
-  D_USAGE, 0x33,							/*     USAGE (Rx) */
-  D_USAGE, 0x34,							/*     USAGE (Ry) */
-  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x80,					/*     _LOGICAL_MINIMUM (-32768) */
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7F,					/*     _LOGICAL_MAXIMUM (32767) */
-  D_REPORT_SIZE, 0x10,							/*     REPORT_SIZE (16) */
-  D_REPORT_COUNT, 0x04,							/*     REPORT_COUNT (4) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*     INPUT (Data,Var,Abs) */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
+  D_COLLECTION, D_PHYSICAL,			/* COLLECTION (Physical) */
+  D_USAGE, 0x30,				/* USAGE (X) */
+  D_USAGE, 0x31,				/* USAGE (Y) */
+  D_USAGE, 0x33,				/* USAGE (Rx) */
+  D_USAGE, 0x34,				/* USAGE (Ry) */
+  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x80,	/* LOGICAL_MINIMUM (-32768) */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7F,	/* LOGICAL_MAXIMUM (32767) */
+  D_REPORT_SIZE, 0x10,				/* REPORT_SIZE (16) */
+  D_REPORT_COUNT, 0x04,				/* REPORT_COUNT (4) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
   /* 2 8bit Axis */
-  D_USAGE, 0x32,							/*     USAGE (Z) */
-  D_USAGE, 0x35,							/*     USAGE (Rz) */
-  D_LOGICAL_MINIMUM, 0x80,							/*     _LOGICAL_MINIMUM (-128) */
-  D_LOGICAL_MAXIMUM, 0x7F,							/*     _LOGICAL_MAXIMUM (127) */
-  D_REPORT_SIZE, 0x08,							/*     REPORT_SIZE (8) */
-  D_REPORT_COUNT, 0x02,							/*     REPORT_COUNT (2) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*     INPUT (Data,Var,Abs) */
-  D_END_COLLECTION,								/*   END_COLLECTION */
-
+  D_USAGE, 0x32,				/* USAGE (Z) */
+  D_USAGE, 0x35,				/* USAGE (Rz) */
+  D_LOGICAL_MINIMUM, 0x80,			/* LOGICAL_MINIMUM (-128) */
+  D_LOGICAL_MAXIMUM, 0x7F,			/* LOGICAL_MAXIMUM (127) */
+  D_REPORT_SIZE, 0x08,				/* REPORT_SIZE (8) */
+  D_REPORT_COUNT, 0x02,				/* REPORT_COUNT (2) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
+  D_END_COLLECTION,				/* END_COLLECTION */
   /* 2 Hat Switches */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/*   USAGE_PAGE (Generic Desktop) */
-  D_USAGE, 0x39,							/*   USAGE (Hat switch) */
-  D_USAGE, 0x39,							/*   USAGE (Hat switch) */
-  D_LOGICAL_MINIMUM, 0x01,							/*   _LOGICAL_MINIMUM (1) */
-  D_LOGICAL_MAXIMUM, 0x08,							/*   _LOGICAL_MAXIMUM (8) */
-  D_REPORT_COUNT, 0x02,							/*   REPORT_COUNT (2) */
-  D_REPORT_SIZE, 0x04,							/*   REPORT_SIZE (4) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),							/*   INPUT (Data,Var,Abs) */
-  D_END_COLLECTION								/* END_COLLECTION */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x39,				/* USAGE (Hat switch) */
+  D_USAGE, 0x39,				/* USAGE (Hat switch) */
+  D_LOGICAL_MINIMUM, 0x01,			/* LOGICAL_MINIMUM (1) */
+  D_LOGICAL_MAXIMUM, 0x08,			/* LOGICAL_MAXIMUM (8) */
+  D_REPORT_COUNT, 0x02,				/* REPORT_COUNT (2) */
+  D_REPORT_SIZE, 0x04,				/* REPORT_SIZE (4) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
+  D_END_COLLECTION				/* END_COLLECTION */
 };
 
 Gamepad_::Gamepad_() {
-  static HIDSubDescriptor node(gamepad_hid_descriptor_, sizeof(gamepad_hid_descriptor_));
+  static HIDSubDescriptor node(gamepad_hid_descriptor_,
+                               sizeof(gamepad_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
-
 
 void Gamepad_::begin() {
   // release all buttons
@@ -95,16 +94,13 @@ void Gamepad_::write() {
   sendReport(&report_, sizeof(report_));
 }
 
-
 void Gamepad_::press(uint8_t b) {
   report_.buttons |= (uint32_t)1 << (b - 1);
 }
 
-
 void Gamepad_::release(uint8_t b) {
   report_.buttons &= ~((uint32_t)1 << (b - 1));
 }
-
 
 void Gamepad_::releaseAll() {
   memset(&report_, 0x00, sizeof(report_));
@@ -114,46 +110,37 @@ void Gamepad_::buttons(uint32_t b) {
   report_.buttons = b;
 }
 
-
 void Gamepad_::xAxis(int16_t a) {
   report_.xAxis = a;
 }
-
 
 void Gamepad_::yAxis(int16_t a) {
   report_.yAxis = a;
 }
 
-
 void Gamepad_::zAxis(int8_t a) {
   report_.zAxis = a;
 }
-
 
 void Gamepad_::rxAxis(int16_t a) {
   report_.rxAxis = a;
 }
 
-
 void Gamepad_::ryAxis(int16_t a) {
   report_.ryAxis = a;
 }
-
 
 void Gamepad_::rzAxis(int8_t a) {
   report_.rzAxis = a;
 }
 
-
 void Gamepad_::dPad1(int8_t d) {
   report_.dPad1 = d;
 }
 
-
 void Gamepad_::dPad2(int8_t d) {
   report_.dPad2 = d;
 }
-
 
 void Gamepad_::sendReport(void* data, int length) {
   HID().SendReport(HID_REPORTID_GAMEPAD, data, length);

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "Gamepad.h"
 #include "DescriptorPrimitives.h"
 
-static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
+static const uint8_t gamepad_hid_descriptor_[] PROGMEM = {
   /* Gamepad with 32 buttons and 6 axis*/
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,							/* USAGE_PAGE (Generic Desktop) */
   D_USAGE, D_USAGE_JOYSTICK,							/* USAGE (Joystick) */
@@ -76,7 +76,7 @@ static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
 };
 
 Gamepad_::Gamepad_() {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorGamepad, sizeof(_hidMultiReportDescriptorGamepad));
+  static HIDSubDescriptor node(gamepad_hid_descriptor_, sizeof(gamepad_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 
@@ -87,71 +87,71 @@ void Gamepad_::begin() {
 }
 
 void Gamepad_::end() {
-  memset(&_report, 0x00, sizeof(_report));
-  sendReport(&_report, sizeof(_report));
+  memset(&report_, 0x00, sizeof(report_));
+  sendReport(&report_, sizeof(report_));
 }
 
 void Gamepad_::write() {
-  sendReport(&_report, sizeof(_report));
+  sendReport(&report_, sizeof(report_));
 }
 
 
 void Gamepad_::press(uint8_t b) {
-  _report.buttons |= (uint32_t)1 << (b - 1);
+  report_.buttons |= (uint32_t)1 << (b - 1);
 }
 
 
 void Gamepad_::release(uint8_t b) {
-  _report.buttons &= ~((uint32_t)1 << (b - 1));
+  report_.buttons &= ~((uint32_t)1 << (b - 1));
 }
 
 
 void Gamepad_::releaseAll() {
-  memset(&_report, 0x00, sizeof(_report));
+  memset(&report_, 0x00, sizeof(report_));
 }
 
 void Gamepad_::buttons(uint32_t b) {
-  _report.buttons = b;
+  report_.buttons = b;
 }
 
 
 void Gamepad_::xAxis(int16_t a) {
-  _report.xAxis = a;
+  report_.xAxis = a;
 }
 
 
 void Gamepad_::yAxis(int16_t a) {
-  _report.yAxis = a;
+  report_.yAxis = a;
 }
 
 
 void Gamepad_::zAxis(int8_t a) {
-  _report.zAxis = a;
+  report_.zAxis = a;
 }
 
 
 void Gamepad_::rxAxis(int16_t a) {
-  _report.rxAxis = a;
+  report_.rxAxis = a;
 }
 
 
 void Gamepad_::ryAxis(int16_t a) {
-  _report.ryAxis = a;
+  report_.ryAxis = a;
 }
 
 
 void Gamepad_::rzAxis(int8_t a) {
-  _report.rzAxis = a;
+  report_.rzAxis = a;
 }
 
 
 void Gamepad_::dPad1(int8_t d) {
-  _report.dPad1 = d;
+  report_.dPad1 = d;
 }
 
 
 void Gamepad_::dPad2(int8_t d) {
-  _report.dPad2 = d;
+  report_.dPad2 = d;
 }
 
 

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -28,50 +28,50 @@ THE SOFTWARE.
 
 static const uint8_t gamepad_hid_descriptor_[] PROGMEM = {
   /* Gamepad with 32 buttons and 6 axis*/
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
-  D_USAGE, D_USAGE_JOYSTICK,			/* USAGE (Joystick) */
-  D_COLLECTION, D_APPLICATION,			/* COLLECTION (Application) */
-  D_REPORT_ID, HID_REPORTID_GAMEPAD,		/* REPORT_ID */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, D_USAGE_JOYSTICK,                    /* USAGE (Joystick) */
+  D_COLLECTION, D_APPLICATION,                  /* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_GAMEPAD,            /* REPORT_ID */
   /* 32 Buttons */
-  D_USAGE_PAGE, D_PAGE_BUTTON,			/* USAGE_PAGE (Button) */
-  D_USAGE_MINIMUM, 0x01,			/* USAGE_MINIMUM (Button 1) */
-  D_USAGE_MAXIMUM, 0x20,			/* USAGE_MAXIMUM (Button 32) */
-  D_LOGICAL_MINIMUM, 0x00,			/* LOGICAL_MINIMUM (0) */
-  D_LOGICAL_MAXIMUM, 0x01,			/* LOGICAL_MAXIMUM (1) */
-  D_REPORT_SIZE, 0x01,				/* REPORT_SIZE (1) */
-  D_REPORT_COUNT, 0x20,				/* REPORT_COUNT (32) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
+  D_USAGE_PAGE, D_PAGE_BUTTON,                  /* USAGE_PAGE (Button) */
+  D_USAGE_MINIMUM, 0x01,                        /* USAGE_MINIMUM (Button 1) */
+  D_USAGE_MAXIMUM, 0x20,                        /* USAGE_MAXIMUM (Button 32) */
+  D_LOGICAL_MINIMUM, 0x00,                      /* LOGICAL_MINIMUM (0) */
+  D_LOGICAL_MAXIMUM, 0x01,                      /* LOGICAL_MAXIMUM (1) */
+  D_REPORT_SIZE, 0x01,                          /* REPORT_SIZE (1) */
+  D_REPORT_COUNT, 0x20,                         /* REPORT_COUNT (32) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),  /* INPUT (Data,Var,Abs) */
   /* 4 16bit Axis */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
-  D_COLLECTION, D_PHYSICAL,			/* COLLECTION (Physical) */
-  D_USAGE, 0x30,				/* USAGE (X) */
-  D_USAGE, 0x31,				/* USAGE (Y) */
-  D_USAGE, 0x33,				/* USAGE (Rx) */
-  D_USAGE, 0x34,				/* USAGE (Ry) */
-  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x80,	/* LOGICAL_MINIMUM (-32768) */
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7F,	/* LOGICAL_MAXIMUM (32767) */
-  D_REPORT_SIZE, 0x10,				/* REPORT_SIZE (16) */
-  D_REPORT_COUNT, 0x04,				/* REPORT_COUNT (4) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop) */
+  D_COLLECTION, D_PHYSICAL,                     /* COLLECTION (Physical) */
+  D_USAGE, 0x30,                                /* USAGE (X) */
+  D_USAGE, 0x31,                                /* USAGE (Y) */
+  D_USAGE, 0x33,                                /* USAGE (Rx) */
+  D_USAGE, 0x34,                                /* USAGE (Ry) */
+  D_MULTIBYTE(D_LOGICAL_MINIMUM), 0x00, 0x80,   /* LOGICAL_MINIMUM (-32768) */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xFF, 0x7F,   /* LOGICAL_MAXIMUM (32767) */
+  D_REPORT_SIZE, 0x10,                          /* REPORT_SIZE (16) */
+  D_REPORT_COUNT, 0x04,                         /* REPORT_COUNT (4) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),  /* INPUT (Data,Var,Abs) */
   /* 2 8bit Axis */
-  D_USAGE, 0x32,				/* USAGE (Z) */
-  D_USAGE, 0x35,				/* USAGE (Rz) */
-  D_LOGICAL_MINIMUM, 0x80,			/* LOGICAL_MINIMUM (-128) */
-  D_LOGICAL_MAXIMUM, 0x7F,			/* LOGICAL_MAXIMUM (127) */
-  D_REPORT_SIZE, 0x08,				/* REPORT_SIZE (8) */
-  D_REPORT_COUNT, 0x02,				/* REPORT_COUNT (2) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
-  D_END_COLLECTION,				/* END_COLLECTION */
+  D_USAGE, 0x32,                                /* USAGE (Z) */
+  D_USAGE, 0x35,                                /* USAGE (Rz) */
+  D_LOGICAL_MINIMUM, 0x80,                      /* LOGICAL_MINIMUM (-128) */
+  D_LOGICAL_MAXIMUM, 0x7F,                      /* LOGICAL_MAXIMUM (127) */
+  D_REPORT_SIZE, 0x08,                          /* REPORT_SIZE (8) */
+  D_REPORT_COUNT, 0x02,                         /* REPORT_COUNT (2) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),  /* INPUT (Data,Var,Abs) */
+  D_END_COLLECTION,                             /* END_COLLECTION */
   /* 2 Hat Switches */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
-  D_USAGE, 0x39,				/* USAGE (Hat switch) */
-  D_USAGE, 0x39,				/* USAGE (Hat switch) */
-  D_LOGICAL_MINIMUM, 0x01,			/* LOGICAL_MINIMUM (1) */
-  D_LOGICAL_MAXIMUM, 0x08,			/* LOGICAL_MAXIMUM (8) */
-  D_REPORT_COUNT, 0x02,				/* REPORT_COUNT (2) */
-  D_REPORT_SIZE, 0x04,				/* REPORT_SIZE (4) */
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),	/* INPUT (Data,Var,Abs) */
-  D_END_COLLECTION				/* END_COLLECTION */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x39,                                /* USAGE (Hat switch) */
+  D_USAGE, 0x39,                                /* USAGE (Hat switch) */
+  D_LOGICAL_MINIMUM, 0x01,                      /* LOGICAL_MINIMUM (1) */
+  D_LOGICAL_MAXIMUM, 0x08,                      /* LOGICAL_MAXIMUM (8) */
+  D_REPORT_COUNT, 0x02,                         /* REPORT_COUNT (2) */
+  D_REPORT_SIZE, 0x04,                          /* REPORT_SIZE (4) */
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),  /* INPUT (Data,Var,Abs) */
+  D_END_COLLECTION                              /* END_COLLECTION */
 };
 
 Gamepad_::Gamepad_() {

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -75,23 +75,23 @@ static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
   D_END_COLLECTION								/* END_COLLECTION */
 };
 
-Gamepad_::Gamepad_(void) {
+Gamepad_::Gamepad_() {
   static HIDSubDescriptor node(_hidMultiReportDescriptorGamepad, sizeof(_hidMultiReportDescriptorGamepad));
   HID().AppendDescriptor(&node);
 }
 
 
-void Gamepad_::begin(void) {
+void Gamepad_::begin() {
   // release all buttons
   end();
 }
 
-void Gamepad_::end(void) {
+void Gamepad_::end() {
   memset(&_report, 0x00, sizeof(_report));
   sendReport(&_report, sizeof(_report));
 }
 
-void Gamepad_::write(void) {
+void Gamepad_::write() {
   sendReport(&_report, sizeof(_report));
 }
 
@@ -106,7 +106,7 @@ void Gamepad_::release(uint8_t b) {
 }
 
 
-void Gamepad_::releaseAll(void) {
+void Gamepad_::releaseAll() {
   memset(&_report, 0x00, sizeof(_report));
 }
 

--- a/src/MultiReport/Gamepad.h
+++ b/src/MultiReport/Gamepad.h
@@ -43,83 +43,83 @@ THE SOFTWARE.
 
 
 typedef union {
-    // 32 Buttons, 6 Axis, 2 D-Pads
-    uint32_t buttons;
+  // 32 Buttons, 6 Axis, 2 D-Pads
+  uint32_t buttons;
 
-    struct {
-        uint8_t button1 : 1;
-        uint8_t button2 : 1;
-        uint8_t button3 : 1;
-        uint8_t button4 : 1;
-        uint8_t button5 : 1;
-        uint8_t button6 : 1;
-        uint8_t button7 : 1;
-        uint8_t button8 : 1;
+  struct {
+    uint8_t button1 : 1;
+    uint8_t button2 : 1;
+    uint8_t button3 : 1;
+    uint8_t button4 : 1;
+    uint8_t button5 : 1;
+    uint8_t button6 : 1;
+    uint8_t button7 : 1;
+    uint8_t button8 : 1;
 
-        uint8_t button9 : 1;
-        uint8_t button10 : 1;
-        uint8_t button11 : 1;
-        uint8_t button12 : 1;
-        uint8_t button13 : 1;
-        uint8_t button14 : 1;
-        uint8_t button15 : 1;
-        uint8_t button16 : 1;
+    uint8_t button9 : 1;
+    uint8_t button10 : 1;
+    uint8_t button11 : 1;
+    uint8_t button12 : 1;
+    uint8_t button13 : 1;
+    uint8_t button14 : 1;
+    uint8_t button15 : 1;
+    uint8_t button16 : 1;
 
-        uint8_t button17 : 1;
-        uint8_t button18 : 1;
-        uint8_t button19 : 1;
-        uint8_t button20 : 1;
-        uint8_t button21 : 1;
-        uint8_t button22 : 1;
-        uint8_t button23 : 1;
-        uint8_t button24 : 1;
+    uint8_t button17 : 1;
+    uint8_t button18 : 1;
+    uint8_t button19 : 1;
+    uint8_t button20 : 1;
+    uint8_t button21 : 1;
+    uint8_t button22 : 1;
+    uint8_t button23 : 1;
+    uint8_t button24 : 1;
 
-        uint8_t button25 : 1;
-        uint8_t button26 : 1;
-        uint8_t button27 : 1;
-        uint8_t button28 : 1;
-        uint8_t button29 : 1;
-        uint8_t button30 : 1;
-        uint8_t button31 : 1;
-        uint8_t button32 : 1;
+    uint8_t button25 : 1;
+    uint8_t button26 : 1;
+    uint8_t button27 : 1;
+    uint8_t button28 : 1;
+    uint8_t button29 : 1;
+    uint8_t button30 : 1;
+    uint8_t button31 : 1;
+    uint8_t button32 : 1;
 
-        int16_t	xAxis;
-        int16_t	yAxis;
+    int16_t	xAxis;
+    int16_t	yAxis;
 
-        int16_t	rxAxis;
-        int16_t	ryAxis;
+    int16_t	rxAxis;
+    int16_t	ryAxis;
 
-        int8_t	zAxis;
-        int8_t	rzAxis;
+    int8_t	zAxis;
+    int8_t	rzAxis;
 
-        uint8_t	dPad1 : 4;
-        uint8_t	dPad2 : 4;
-    };
+    uint8_t	dPad1 : 4;
+    uint8_t	dPad2 : 4;
+  };
 } HID_GamepadReport_Data_t;
 
 class Gamepad_ {
-  public:
-    Gamepad_(void);
+ public:
+  Gamepad_(void);
 
-    void begin(void);
-    void end(void);
-    void write(void);
-    void press(uint8_t b);
-    void release(uint8_t b);
-    void releaseAll(void);
+  void begin(void);
+  void end(void);
+  void write(void);
+  void press(uint8_t b);
+  void release(uint8_t b);
+  void releaseAll(void);
 
-    void buttons(uint32_t b);
-    void xAxis(int16_t a);
-    void yAxis(int16_t a);
-    void zAxis(int8_t a);
-    void rxAxis(int16_t a);
-    void ryAxis(int16_t a);
-    void rzAxis(int8_t a);
-    void dPad1(int8_t d);
-    void dPad2(int8_t d);
+  void buttons(uint32_t b);
+  void xAxis(int16_t a);
+  void yAxis(int16_t a);
+  void zAxis(int8_t a);
+  void rxAxis(int16_t a);
+  void ryAxis(int16_t a);
+  void rzAxis(int8_t a);
+  void dPad1(int8_t d);
+  void dPad2(int8_t d);
 
-    void sendReport(void* data, int length);
-  protected:
-    HID_GamepadReport_Data_t _report;
+  void sendReport(void* data, int length);
+ protected:
+  HID_GamepadReport_Data_t _report;
 };
 extern Gamepad_ Gamepad;

--- a/src/MultiReport/Gamepad.h
+++ b/src/MultiReport/Gamepad.h
@@ -120,6 +120,6 @@ class Gamepad_ {
 
   void sendReport(void* data, int length);
  protected:
-  HID_GamepadReport_Data_t _report;
+  HID_GamepadReport_Data_t report_;
 };
 extern Gamepad_ Gamepad;

--- a/src/MultiReport/Gamepad.h
+++ b/src/MultiReport/Gamepad.h
@@ -99,14 +99,14 @@ typedef union {
 
 class Gamepad_ {
  public:
-  Gamepad_(void);
+  Gamepad_();
 
-  void begin(void);
-  void end(void);
-  void write(void);
+  void begin();
+  void end();
+  void write();
   void press(uint8_t b);
   void release(uint8_t b);
-  void releaseAll(void);
+  void releaseAll();
 
   void buttons(uint32_t b);
   void xAxis(int16_t a);

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -27,164 +27,164 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 static const uint8_t _hidMultiReportDescriptorKeyboard[] PROGMEM = {
-    //  NKRO Keyboard
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,
-    D_USAGE, D_USAGE_KEYBOARD,
-    D_COLLECTION, D_APPLICATION,
-    D_REPORT_ID, HID_REPORTID_NKRO_KEYBOARD,
-    D_USAGE_PAGE, D_PAGE_KEYBOARD,
+  //  NKRO Keyboard
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,
+  D_USAGE, D_USAGE_KEYBOARD,
+  D_COLLECTION, D_APPLICATION,
+  D_REPORT_ID, HID_REPORTID_NKRO_KEYBOARD,
+  D_USAGE_PAGE, D_PAGE_KEYBOARD,
 
 
-    /* Key modifier byte */
-    D_USAGE_MINIMUM, HID_KEYBOARD_FIRST_MODIFIER,
-    D_USAGE_MAXIMUM, HID_KEYBOARD_LAST_MODIFIER,
-    D_LOGICAL_MINIMUM, 0x00,
-    D_LOGICAL_MAXIMUM, 0x01,
-    D_REPORT_SIZE, 0x01,
-    D_REPORT_COUNT, 0x08,
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),
+  /* Key modifier byte */
+  D_USAGE_MINIMUM, HID_KEYBOARD_FIRST_MODIFIER,
+  D_USAGE_MAXIMUM, HID_KEYBOARD_LAST_MODIFIER,
+  D_LOGICAL_MINIMUM, 0x00,
+  D_LOGICAL_MAXIMUM, 0x01,
+  D_REPORT_SIZE, 0x01,
+  D_REPORT_COUNT, 0x08,
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
 
 
-    /* 5 LEDs for num lock etc, 3 left for advanced, custom usage */
-    D_USAGE_PAGE, D_PAGE_LEDS,
-    D_USAGE_MINIMUM, 0x01,
-    D_USAGE_MAXIMUM, 0x08,
-    D_REPORT_COUNT, 0x08,
-    D_REPORT_SIZE, 0x01,
-    D_OUTPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
+  /* 5 LEDs for num lock etc, 3 left for advanced, custom usage */
+  D_USAGE_PAGE, D_PAGE_LEDS,
+  D_USAGE_MINIMUM, 0x01,
+  D_USAGE_MAXIMUM, 0x08,
+  D_REPORT_COUNT, 0x08,
+  D_REPORT_SIZE, 0x01,
+  D_OUTPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
 
-    /* NKRO Keyboard */
-    D_USAGE_PAGE, D_PAGE_KEYBOARD,
+  /* NKRO Keyboard */
+  D_USAGE_PAGE, D_PAGE_KEYBOARD,
 
-    // Padding 4 bits, to skip NO_EVENT & 3 error states.
-    D_REPORT_SIZE, 0x04,
-    D_REPORT_COUNT, 0x01,
-    D_INPUT, (D_CONSTANT),
+  // Padding 4 bits, to skip NO_EVENT & 3 error states.
+  D_REPORT_SIZE, 0x04,
+  D_REPORT_COUNT, 0x01,
+  D_INPUT, (D_CONSTANT),
 
-    D_USAGE_MINIMUM, HID_KEYBOARD_A_AND_A,
-    D_USAGE_MAXIMUM, HID_LAST_KEY,
-    D_LOGICAL_MINIMUM, 0x00,
-    D_LOGICAL_MAXIMUM, 0x01,
-    D_REPORT_SIZE, 0x01,
-    D_REPORT_COUNT, (HID_LAST_KEY - HID_KEYBOARD_A_AND_A),
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),
+  D_USAGE_MINIMUM, HID_KEYBOARD_A_AND_A,
+  D_USAGE_MAXIMUM, HID_LAST_KEY,
+  D_LOGICAL_MINIMUM, 0x00,
+  D_LOGICAL_MAXIMUM, 0x01,
+  D_REPORT_SIZE, 0x01,
+  D_REPORT_COUNT, (HID_LAST_KEY - HID_KEYBOARD_A_AND_A),
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
 
-    // Padding (3 bits) to round up the report to byte boundary.
-    D_REPORT_SIZE, 0x03,
-    D_REPORT_COUNT, 0x01,
-    D_INPUT, (D_CONSTANT),
+  // Padding (3 bits) to round up the report to byte boundary.
+  D_REPORT_SIZE, 0x03,
+  D_REPORT_COUNT, 0x01,
+  D_INPUT, (D_CONSTANT),
 
-    D_END_COLLECTION,
+  D_END_COLLECTION,
 
 };
 
 Keyboard_::Keyboard_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
-    HID().AppendDescriptor(&node);
+  static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
+  HID().AppendDescriptor(&node);
 }
 
 void Keyboard_::begin(void) {
-    // Force API to send a clean report.
-    // This is important for and HID bridge where the receiver stays on,
-    // while the sender is resetted.
-    releaseAll();
-    sendReportUnchecked();
+  // Force API to send a clean report.
+  // This is important for and HID bridge where the receiver stays on,
+  // while the sender is resetted.
+  releaseAll();
+  sendReportUnchecked();
 }
 
 
 void Keyboard_::end(void) {
-    releaseAll();
-    sendReportUnchecked();
+  releaseAll();
+  sendReportUnchecked();
 }
 
 int Keyboard_::sendReportUnchecked(void) {
-    return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));
+  return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));
 }
 
 
 int Keyboard_::sendReport(void) {
-    // If the last report is different than the current report, then we need to send a report.
-    // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
-    // if sendReport is called in a tight loop.
+  // If the last report is different than the current report, then we need to send a report.
+  // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
+  // if sendReport is called in a tight loop.
 
-    if (memcmp(lastKeyReport.allkeys, keyReport.allkeys, sizeof(keyReport))) {
-        // if the two reports are different, send a report
+  if (memcmp(lastKeyReport.allkeys, keyReport.allkeys, sizeof(keyReport))) {
+    // if the two reports are different, send a report
 
-        // ChromeOS 51-60 (at least) bug: if a modifier and a normal keycode are added in the
-        // same report, in some cases the shift is not applied (e.g. `shift`+`[` doesn't yield
-        // `{`). To compensate for this, check to see if the modifier byte has changed.
-
-
-        // If modifiers are being turned on at the same time as any change
-        // to the non-modifier keys in the report, then we send the previous
-        // report with the new modifiers
-        if ( ( (lastKeyReport.modifiers ^ keyReport.modifiers) & keyReport.modifiers)
-                && (memcmp(lastKeyReport.keys,keyReport.keys, sizeof(keyReport.keys)))) {
-            uint8_t last_mods = lastKeyReport.modifiers;
-            lastKeyReport.modifiers = keyReport.modifiers;
-            int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
-            lastKeyReport.modifiers = last_mods;
-        }
-
-        // If modifiers are being turned off, then we send the new report with the previous modifiers.
-        // We need to do this, at least on Linux 4.17 + Wayland.
-        // Jesse has observed that sending Shift + 3 key up events in the same report
-        // will sometimes result in a spurious '3' rather than '#', especially when the keys
-        // had been held for a while
-        else if (( (lastKeyReport.modifiers ^ keyReport.modifiers) & lastKeyReport.modifiers)
-                 && (memcmp(lastKeyReport.keys,keyReport.keys, sizeof(keyReport.keys)))) {
-            uint8_t mods = keyReport.modifiers;
-            keyReport.modifiers = lastKeyReport.modifiers;
-            int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(lastKeyReport));
-            keyReport.modifiers = mods;
-        }
+    // ChromeOS 51-60 (at least) bug: if a modifier and a normal keycode are added in the
+    // same report, in some cases the shift is not applied (e.g. `shift`+`[` doesn't yield
+    // `{`). To compensate for this, check to see if the modifier byte has changed.
 
 
-
-
-
-        int returnCode = sendReportUnchecked();
-        if (returnCode > 0)
-            memcpy(lastKeyReport.allkeys, keyReport.allkeys, sizeof(keyReport));
-        return returnCode;
+    // If modifiers are being turned on at the same time as any change
+    // to the non-modifier keys in the report, then we send the previous
+    // report with the new modifiers
+    if (((lastKeyReport.modifiers ^ keyReport.modifiers) & keyReport.modifiers)
+        && (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))) {
+      uint8_t last_mods = lastKeyReport.modifiers;
+      lastKeyReport.modifiers = keyReport.modifiers;
+      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
+      lastKeyReport.modifiers = last_mods;
     }
-    return -1;
+
+    // If modifiers are being turned off, then we send the new report with the previous modifiers.
+    // We need to do this, at least on Linux 4.17 + Wayland.
+    // Jesse has observed that sending Shift + 3 key up events in the same report
+    // will sometimes result in a spurious '3' rather than '#', especially when the keys
+    // had been held for a while
+    else if (((lastKeyReport.modifiers ^ keyReport.modifiers) & lastKeyReport.modifiers)
+             && (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))) {
+      uint8_t mods = keyReport.modifiers;
+      keyReport.modifiers = lastKeyReport.modifiers;
+      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(lastKeyReport));
+      keyReport.modifiers = mods;
+    }
+
+
+
+
+
+    int returnCode = sendReportUnchecked();
+    if (returnCode > 0)
+      memcpy(lastKeyReport.allkeys, keyReport.allkeys, sizeof(keyReport));
+    return returnCode;
+  }
+  return -1;
 }
 
 /* Returns true if the modifer key passed in will be sent during this key report
  * Returns false in all other cases
  * */
 boolean Keyboard_::isModifierActive(uint8_t k) {
-    if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
-        k = k - HID_KEYBOARD_FIRST_MODIFIER;
-        return !!(keyReport.modifiers & (1 << k));
-    }
-    return false;
+  if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    return !!(keyReport.modifiers & (1 << k));
+  }
+  return false;
 }
 
 /* Returns true if the modifer key passed in was being sent during the previous key report
  * Returns false in all other cases
  * */
 boolean Keyboard_::wasModifierActive(uint8_t k) {
-    if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
-        k = k - HID_KEYBOARD_FIRST_MODIFIER;
-        return !!(lastKeyReport.modifiers & (1 << k));
-    }
-    return false;
+  if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    return !!(lastKeyReport.modifiers & (1 << k));
+  }
+  return false;
 }
 
 /* Returns true if *any* modifier will be sent during this key report
  * Returns false in all other cases
  * */
 boolean Keyboard_::isAnyModifierActive() {
-    return keyReport.modifiers > 0;
+  return keyReport.modifiers > 0;
 }
 
 /* Returns true if *any* modifier was being sent during the previous key report
  * Returns false in all other cases
  * */
 boolean Keyboard_::wasAnyModifierActive() {
-    return lastKeyReport.modifiers > 0;
+  return lastKeyReport.modifiers > 0;
 }
 
 
@@ -192,11 +192,11 @@ boolean Keyboard_::wasAnyModifierActive() {
  * Returns false in all other cases
  * */
 boolean Keyboard_::isKeyPressed(uint8_t k) {
-    if (k <= HID_LAST_KEY) {
-        uint8_t bit = 1 << (uint8_t(k) % 8);
-        return !! (keyReport.keys[k / 8] & bit);
-    }
-    return false;
+  if (k <= HID_LAST_KEY) {
+    uint8_t bit = 1 << (uint8_t(k) % 8);
+    return !!(keyReport.keys[k / 8] & bit);
+  }
+  return false;
 }
 
 /* Returns true if the non-modifer key passed in was sent during the previous key report
@@ -204,57 +204,57 @@ boolean Keyboard_::isKeyPressed(uint8_t k) {
  * */
 boolean Keyboard_::wasKeyPressed(uint8_t k) {
 
-    if (k <= HID_LAST_KEY) {
-        uint8_t bit = 1 << (uint8_t(k) % 8);
-        return !! (lastKeyReport.keys[k / 8] & bit);
-    }
-    return false;
+  if (k <= HID_LAST_KEY) {
+    uint8_t bit = 1 << (uint8_t(k) % 8);
+    return !!(lastKeyReport.keys[k / 8] & bit);
+  }
+  return false;
 }
 
 
 size_t Keyboard_::press(uint8_t k) {
-    // If the key is in the range of 'printable' keys
-    if (k <= HID_LAST_KEY) {
-        uint8_t bit = 1 << (uint8_t(k) % 8);
-        keyReport.keys[k / 8] |= bit;
-        return 1;
-    }
+  // If the key is in the range of 'printable' keys
+  if (k <= HID_LAST_KEY) {
+    uint8_t bit = 1 << (uint8_t(k) % 8);
+    keyReport.keys[k / 8] |= bit;
+    return 1;
+  }
 
-    // It's a modifier key
-    else if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
-        // Convert key into bitfield (0 - 7)
-        k = k - HID_KEYBOARD_FIRST_MODIFIER;
-        keyReport.modifiers |= (1 << k);
-        return 1;
-    }
+  // It's a modifier key
+  else if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    // Convert key into bitfield (0 - 7)
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    keyReport.modifiers |= (1 << k);
+    return 1;
+  }
 
-    // No empty/pressed key was found
-    return 0;
+  // No empty/pressed key was found
+  return 0;
 }
 
 size_t Keyboard_::release(uint8_t k) {
-    // If we're releasing a printable key
-    if (k <= HID_LAST_KEY) {
-        uint8_t bit = 1 << (k % 8);
-        keyReport.keys[k / 8] &= ~bit;
-        return 1;
-    }
+  // If we're releasing a printable key
+  if (k <= HID_LAST_KEY) {
+    uint8_t bit = 1 << (k % 8);
+    keyReport.keys[k / 8] &= ~bit;
+    return 1;
+  }
 
-    // It's a modifier key
-    else if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
-        // Convert key into bitfield (0 - 7)
-        k = k - HID_KEYBOARD_FIRST_MODIFIER;
-        keyReport.modifiers &= ~(1 << k);
-        return 1;
-    }
+  // It's a modifier key
+  else if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
+    // Convert key into bitfield (0 - 7)
+    k = k - HID_KEYBOARD_FIRST_MODIFIER;
+    keyReport.modifiers &= ~(1 << k);
+    return 1;
+  }
 
-    // No empty/pressed key was found
-    return 0;
+  // No empty/pressed key was found
+  return 0;
 }
 
 void Keyboard_::releaseAll(void) {
-    // Release all keys
-    memset(&keyReport.allkeys, 0x00, sizeof(keyReport.allkeys));
+  // Release all keys
+  memset(&keyReport.allkeys, 0x00, sizeof(keyReport.allkeys));
 }
 
 Keyboard_ Keyboard;

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -154,7 +154,7 @@ int Keyboard_::sendReport() {
 /* Returns true if the modifer key passed in will be sent during this key report
  * Returns false in all other cases
  * */
-boolean Keyboard_::isModifierActive(uint8_t k) {
+bool Keyboard_::isModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
     return !!(keyReport.modifiers & (1 << k));
@@ -165,7 +165,7 @@ boolean Keyboard_::isModifierActive(uint8_t k) {
 /* Returns true if the modifer key passed in was being sent during the previous key report
  * Returns false in all other cases
  * */
-boolean Keyboard_::wasModifierActive(uint8_t k) {
+bool Keyboard_::wasModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
     return !!(lastKeyReport.modifiers & (1 << k));
@@ -176,14 +176,14 @@ boolean Keyboard_::wasModifierActive(uint8_t k) {
 /* Returns true if *any* modifier will be sent during this key report
  * Returns false in all other cases
  * */
-boolean Keyboard_::isAnyModifierActive() {
+bool Keyboard_::isAnyModifierActive() {
   return keyReport.modifiers > 0;
 }
 
 /* Returns true if *any* modifier was being sent during the previous key report
  * Returns false in all other cases
  * */
-boolean Keyboard_::wasAnyModifierActive() {
+bool Keyboard_::wasAnyModifierActive() {
   return lastKeyReport.modifiers > 0;
 }
 
@@ -191,7 +191,7 @@ boolean Keyboard_::wasAnyModifierActive() {
 /* Returns true if the non-modifier key passed in will be sent during this key report
  * Returns false in all other cases
  * */
-boolean Keyboard_::isKeyPressed(uint8_t k) {
+bool Keyboard_::isKeyPressed(uint8_t k) {
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (uint8_t(k) % 8);
     return !!(keyReport.keys[k / 8] & bit);
@@ -202,7 +202,7 @@ boolean Keyboard_::isKeyPressed(uint8_t k) {
 /* Returns true if the non-modifer key passed in was sent during the previous key report
  * Returns false in all other cases
  * */
-boolean Keyboard_::wasKeyPressed(uint8_t k) {
+bool Keyboard_::wasKeyPressed(uint8_t k) {
 
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (uint8_t(k) % 8);

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -78,12 +78,12 @@ static const uint8_t _hidMultiReportDescriptorKeyboard[] PROGMEM = {
 
 };
 
-Keyboard_::Keyboard_(void) {
+Keyboard_::Keyboard_() {
   static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
   HID().AppendDescriptor(&node);
 }
 
-void Keyboard_::begin(void) {
+void Keyboard_::begin() {
   // Force API to send a clean report.
   // This is important for and HID bridge where the receiver stays on,
   // while the sender is resetted.
@@ -92,17 +92,17 @@ void Keyboard_::begin(void) {
 }
 
 
-void Keyboard_::end(void) {
+void Keyboard_::end() {
   releaseAll();
   sendReportUnchecked();
 }
 
-int Keyboard_::sendReportUnchecked(void) {
+int Keyboard_::sendReportUnchecked() {
   return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));
 }
 
 
-int Keyboard_::sendReport(void) {
+int Keyboard_::sendReport() {
   // If the last report is different than the current report, then we need to send a report.
   // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
   // if sendReport is called in a tight loop.
@@ -252,7 +252,7 @@ size_t Keyboard_::release(uint8_t k) {
   return 0;
 }
 
-void Keyboard_::releaseAll(void) {
+void Keyboard_::releaseAll() {
   // Release all keys
   memset(&keyReport.allkeys, 0x00, sizeof(keyReport.allkeys));
 }

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "Keyboard.h"
 #include "DescriptorPrimitives.h"
 
-static const uint8_t _hidMultiReportDescriptorKeyboard[] PROGMEM = {
+static const uint8_t nkro_keyboard_hid_descriptor_[] PROGMEM = {
   //  NKRO Keyboard
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,
   D_USAGE, D_USAGE_KEYBOARD,
@@ -79,7 +79,7 @@ static const uint8_t _hidMultiReportDescriptorKeyboard[] PROGMEM = {
 };
 
 Keyboard_::Keyboard_() {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorKeyboard, sizeof(_hidMultiReportDescriptorKeyboard));
+  static HIDSubDescriptor node(nkro_keyboard_hid_descriptor_, sizeof(nkro_keyboard_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 
@@ -98,7 +98,7 @@ void Keyboard_::end() {
 }
 
 int Keyboard_::sendReportUnchecked() {
-  return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(keyReport));
+  return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &key_report_, sizeof(key_report_));
 }
 
 
@@ -107,7 +107,7 @@ int Keyboard_::sendReport() {
   // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
   // if sendReport is called in a tight loop.
 
-  if (memcmp(lastKeyReport.allkeys, keyReport.allkeys, sizeof(keyReport))) {
+  if (memcmp(last_key_report_.allkeys, key_report_.allkeys, sizeof(key_report_))) {
     // if the two reports are different, send a report
 
     // ChromeOS 51-60 (at least) bug: if a modifier and a normal keycode are added in the
@@ -118,12 +118,12 @@ int Keyboard_::sendReport() {
     // If modifiers are being turned on at the same time as any change
     // to the non-modifier keys in the report, then we send the previous
     // report with the new modifiers
-    if (((lastKeyReport.modifiers ^ keyReport.modifiers) & keyReport.modifiers)
-        && (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))) {
-      uint8_t last_mods = lastKeyReport.modifiers;
-      lastKeyReport.modifiers = keyReport.modifiers;
-      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &lastKeyReport, sizeof(lastKeyReport));
-      lastKeyReport.modifiers = last_mods;
+    if (((last_key_report_.modifiers ^ key_report_.modifiers) & key_report_.modifiers)
+        && (memcmp(last_key_report_.keys, key_report_.keys, sizeof(key_report_.keys)))) {
+      uint8_t last_mods = last_key_report_.modifiers;
+      last_key_report_.modifiers = key_report_.modifiers;
+      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &last_key_report_, sizeof(last_key_report_));
+      last_key_report_.modifiers = last_mods;
     }
 
     // If modifiers are being turned off, then we send the new report with the previous modifiers.
@@ -131,12 +131,12 @@ int Keyboard_::sendReport() {
     // Jesse has observed that sending Shift + 3 key up events in the same report
     // will sometimes result in a spurious '3' rather than '#', especially when the keys
     // had been held for a while
-    else if (((lastKeyReport.modifiers ^ keyReport.modifiers) & lastKeyReport.modifiers)
-             && (memcmp(lastKeyReport.keys, keyReport.keys, sizeof(keyReport.keys)))) {
-      uint8_t mods = keyReport.modifiers;
-      keyReport.modifiers = lastKeyReport.modifiers;
-      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &keyReport, sizeof(lastKeyReport));
-      keyReport.modifiers = mods;
+    else if (((last_key_report_.modifiers ^ key_report_.modifiers) & last_key_report_.modifiers)
+             && (memcmp(last_key_report_.keys, key_report_.keys, sizeof(key_report_.keys)))) {
+      uint8_t mods = key_report_.modifiers;
+      key_report_.modifiers = last_key_report_.modifiers;
+      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &key_report_, sizeof(last_key_report_));
+      key_report_.modifiers = mods;
     }
 
 
@@ -145,7 +145,7 @@ int Keyboard_::sendReport() {
 
     int returnCode = sendReportUnchecked();
     if (returnCode > 0)
-      memcpy(lastKeyReport.allkeys, keyReport.allkeys, sizeof(keyReport));
+      memcpy(last_key_report_.allkeys, key_report_.allkeys, sizeof(key_report_));
     return returnCode;
   }
   return -1;
@@ -157,7 +157,7 @@ int Keyboard_::sendReport() {
 bool Keyboard_::isModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
-    return !!(keyReport.modifiers & (1 << k));
+    return !!(key_report_.modifiers & (1 << k));
   }
   return false;
 }
@@ -168,7 +168,7 @@ bool Keyboard_::isModifierActive(uint8_t k) {
 bool Keyboard_::wasModifierActive(uint8_t k) {
   if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
-    return !!(lastKeyReport.modifiers & (1 << k));
+    return !!(last_key_report_.modifiers & (1 << k));
   }
   return false;
 }
@@ -177,14 +177,14 @@ bool Keyboard_::wasModifierActive(uint8_t k) {
  * Returns false in all other cases
  * */
 bool Keyboard_::isAnyModifierActive() {
-  return keyReport.modifiers > 0;
+  return key_report_.modifiers > 0;
 }
 
 /* Returns true if *any* modifier was being sent during the previous key report
  * Returns false in all other cases
  * */
 bool Keyboard_::wasAnyModifierActive() {
-  return lastKeyReport.modifiers > 0;
+  return last_key_report_.modifiers > 0;
 }
 
 
@@ -194,7 +194,7 @@ bool Keyboard_::wasAnyModifierActive() {
 bool Keyboard_::isKeyPressed(uint8_t k) {
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (uint8_t(k) % 8);
-    return !!(keyReport.keys[k / 8] & bit);
+    return !!(key_report_.keys[k / 8] & bit);
   }
   return false;
 }
@@ -206,7 +206,7 @@ bool Keyboard_::wasKeyPressed(uint8_t k) {
 
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (uint8_t(k) % 8);
-    return !!(lastKeyReport.keys[k / 8] & bit);
+    return !!(last_key_report_.keys[k / 8] & bit);
   }
   return false;
 }
@@ -216,7 +216,7 @@ size_t Keyboard_::press(uint8_t k) {
   // If the key is in the range of 'printable' keys
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (uint8_t(k) % 8);
-    keyReport.keys[k / 8] |= bit;
+    key_report_.keys[k / 8] |= bit;
     return 1;
   }
 
@@ -224,7 +224,7 @@ size_t Keyboard_::press(uint8_t k) {
   else if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     // Convert key into bitfield (0 - 7)
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
-    keyReport.modifiers |= (1 << k);
+    key_report_.modifiers |= (1 << k);
     return 1;
   }
 
@@ -236,7 +236,7 @@ size_t Keyboard_::release(uint8_t k) {
   // If we're releasing a printable key
   if (k <= HID_LAST_KEY) {
     uint8_t bit = 1 << (k % 8);
-    keyReport.keys[k / 8] &= ~bit;
+    key_report_.keys[k / 8] &= ~bit;
     return 1;
   }
 
@@ -244,7 +244,7 @@ size_t Keyboard_::release(uint8_t k) {
   else if (k >= HID_KEYBOARD_FIRST_MODIFIER && k <= HID_KEYBOARD_LAST_MODIFIER) {
     // Convert key into bitfield (0 - 7)
     k = k - HID_KEYBOARD_FIRST_MODIFIER;
-    keyReport.modifiers &= ~(1 << k);
+    key_report_.modifiers &= ~(1 << k);
     return 1;
   }
 
@@ -254,7 +254,7 @@ size_t Keyboard_::release(uint8_t k) {
 
 void Keyboard_::releaseAll() {
   // Release all keys
-  memset(&keyReport.allkeys, 0x00, sizeof(keyReport.allkeys));
+  memset(&key_report_.allkeys, 0x00, sizeof(key_report_.allkeys));
 }
 
 Keyboard_ Keyboard;

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -68,8 +68,8 @@ class Keyboard_ {
     return HID().getLEDs();
   };
 
-  HID_KeyboardReport_Data_t key_report_;
-  HID_KeyboardReport_Data_t last_key_report_;
+  HID_KeyboardReport_Data_t report_;
+  HID_KeyboardReport_Data_t last_report_;
  private:
   int sendReportUnchecked();
 };

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -45,7 +45,6 @@ typedef union {
 } HID_KeyboardReport_Data_t;
 
 
-
 class Keyboard_ {
  public:
   Keyboard_();

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -57,12 +57,12 @@ class Keyboard_ {
   void  releaseAll();
   int sendReport();
 
-  boolean isKeyPressed(uint8_t k);
-  boolean wasKeyPressed(uint8_t k);
-  boolean isModifierActive(uint8_t k);
-  boolean wasModifierActive(uint8_t k);
-  boolean isAnyModifierActive();
-  boolean wasAnyModifierActive();
+  bool isKeyPressed(uint8_t k);
+  bool wasKeyPressed(uint8_t k);
+  bool isModifierActive(uint8_t k);
+  bool wasModifierActive(uint8_t k);
+  bool isAnyModifierActive();
+  bool wasAnyModifierActive();
 
   uint8_t getLEDs() {
     return HID().getLEDs();

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -48,14 +48,14 @@ typedef union {
 
 class Keyboard_ {
  public:
-  Keyboard_(void);
-  void begin(void);
-  void end(void);
+  Keyboard_();
+  void begin();
+  void end();
 
   size_t press(uint8_t k);
   size_t release(uint8_t k);
-  void  releaseAll(void);
-  int sendReport(void);
+  void  releaseAll();
+  int sendReport();
 
   boolean isKeyPressed(uint8_t k);
   boolean wasKeyPressed(uint8_t k);
@@ -71,6 +71,6 @@ class Keyboard_ {
   HID_KeyboardReport_Data_t keyReport;
   HID_KeyboardReport_Data_t lastKeyReport;
  private:
-  int sendReportUnchecked(void);
+  int sendReportUnchecked();
 };
 extern Keyboard_ Keyboard;

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -68,8 +68,8 @@ class Keyboard_ {
     return HID().getLEDs();
   };
 
-  HID_KeyboardReport_Data_t keyReport;
-  HID_KeyboardReport_Data_t lastKeyReport;
+  HID_KeyboardReport_Data_t key_report_;
+  HID_KeyboardReport_Data_t last_key_report_;
  private:
   int sendReportUnchecked();
 };

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -36,41 +36,41 @@ THE SOFTWARE.
 #define KEY_BYTES 28
 
 typedef union {
-    // Modifiers + keymap
-    struct {
-        uint8_t modifiers;
-        uint8_t keys[KEY_BYTES ];
-    };
-    uint8_t allkeys[1 + KEY_BYTES];
+  // Modifiers + keymap
+  struct {
+    uint8_t modifiers;
+    uint8_t keys[KEY_BYTES ];
+  };
+  uint8_t allkeys[1 + KEY_BYTES];
 } HID_KeyboardReport_Data_t;
 
 
 
 class Keyboard_ {
-  public:
-    Keyboard_(void);
-    void begin(void);
-    void end(void);
+ public:
+  Keyboard_(void);
+  void begin(void);
+  void end(void);
 
-    size_t press(uint8_t k);
-    size_t release(uint8_t k);
-    void  releaseAll(void);
-    int sendReport(void);
+  size_t press(uint8_t k);
+  size_t release(uint8_t k);
+  void  releaseAll(void);
+  int sendReport(void);
 
-    boolean isKeyPressed(uint8_t k);
-    boolean wasKeyPressed(uint8_t k);
-    boolean isModifierActive(uint8_t k);
-    boolean wasModifierActive(uint8_t k);
-    boolean isAnyModifierActive();
-    boolean wasAnyModifierActive();
+  boolean isKeyPressed(uint8_t k);
+  boolean wasKeyPressed(uint8_t k);
+  boolean isModifierActive(uint8_t k);
+  boolean wasModifierActive(uint8_t k);
+  boolean isAnyModifierActive();
+  boolean wasAnyModifierActive();
 
-    uint8_t getLEDs() {
-        return HID().getLEDs();
-    };
+  uint8_t getLEDs() {
+    return HID().getLEDs();
+  };
 
-    HID_KeyboardReport_Data_t keyReport;
-    HID_KeyboardReport_Data_t lastKeyReport;
-  private:
-    int sendReportUnchecked(void);
+  HID_KeyboardReport_Data_t keyReport;
+  HID_KeyboardReport_Data_t lastKeyReport;
+ private:
+  int sendReportUnchecked(void);
 };
 extern Keyboard_ Keyboard;

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -29,39 +29,39 @@ THE SOFTWARE.
 static const uint8_t mouse_hid_descriptor_[] PROGMEM = {
   /*  Mouse relative */
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
-  D_USAGE, D_USAGE_MOUSE,                         //  USAGE (Mouse)
-  D_COLLECTION, D_APPLICATION,                    //   COLLECTION (Application)
-  D_REPORT_ID, HID_REPORTID_MOUSE,                //    REPORT_ID (Mouse)
+  D_USAGE, D_USAGE_MOUSE,                         // USAGE (Mouse)
+  D_COLLECTION, D_APPLICATION,                    // COLLECTION (Application)
+  D_REPORT_ID, HID_REPORTID_MOUSE,                // REPORT_ID (Mouse)
 
   /* 8 Buttons */
-  D_USAGE_PAGE, D_PAGE_BUTTON,                    //    USAGE_PAGE (Button)
-  D_USAGE_MINIMUM, 0x01,                          //     USAGE_MINIMUM (Button 1)
-  D_USAGE_MAXIMUM, 0x08,                          //     USAGE_MAXIMUM (Button 8)
-  D_LOGICAL_MINIMUM, 0x00,                        //     LOGICAL_MINIMUM (0)
-  D_LOGICAL_MAXIMUM, 0x01,                        //     LOGICAL_MAXIMUM (1)
-  D_REPORT_COUNT, 0x08,                           //     REPORT_COUNT (8)
-  D_REPORT_SIZE, 0x01,                            //     REPORT_SIZE (1)
-  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),    //     INPUT (Data,Var,Abs)
+  D_USAGE_PAGE, D_PAGE_BUTTON,                    // USAGE_PAGE (Button)
+  D_USAGE_MINIMUM, 0x01,                          // USAGE_MINIMUM (Button 1)
+  D_USAGE_MAXIMUM, 0x08,                          // USAGE_MAXIMUM (Button 8)
+  D_LOGICAL_MINIMUM, 0x00,                        // LOGICAL_MINIMUM (0)
+  D_LOGICAL_MAXIMUM, 0x01,                        // LOGICAL_MAXIMUM (1)
+  D_REPORT_COUNT, 0x08,                           // REPORT_COUNT (8)
+  D_REPORT_SIZE, 0x01,                            // REPORT_SIZE (1)
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),    // INPUT (Data,Var,Abs)
 
   /* X, Y, Wheel */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           //    USAGE_PAGE (Generic Desktop)
-  D_USAGE, 0x30,                                  //     USAGE (X)
-  D_USAGE, 0x31,                                  //     USAGE (Y)
-  D_USAGE, 0x38,                                  //     USAGE (Wheel)
-  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
-  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
-  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
-  D_REPORT_COUNT, 0x03,                           //     REPORT_COUNT (3)
-  D_INPUT, (D_DATA | D_VARIABLE | D_RELATIVE),    //     INPUT (Data,Var,Rel)
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
+  D_USAGE, 0x30,                                  // USAGE (X)
+  D_USAGE, 0x31,                                  // USAGE (Y)
+  D_USAGE, 0x38,                                  // USAGE (Wheel)
+  D_LOGICAL_MINIMUM, 0x81,                        // LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        // LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            // REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x03,                           // REPORT_COUNT (3)
+  D_INPUT, (D_DATA | D_VARIABLE | D_RELATIVE),    // INPUT (Data,Var,Rel)
 
   /* Horizontal wheel */
-  D_USAGE_PAGE, D_PAGE_CONSUMER,                  //    USAGE_PAGE (Consumer)
-  D_PAGE_ORDINAL, 0x38, 0x02,                     //     PAGE (AC Pan)
-  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
-  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
-  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
-  D_REPORT_COUNT, 0x01,                           //     REPORT_COUNT (1)
-  D_INPUT, (D_DATA | D_VARIABLE | D_RELATIVE),    //     INPUT (Data,Var,Rel)
+  D_USAGE_PAGE, D_PAGE_CONSUMER,                  // USAGE_PAGE (Consumer)
+  D_PAGE_ORDINAL, 0x38, 0x02,                     // PAGE (AC Pan)
+  D_LOGICAL_MINIMUM, 0x81,                        // LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        // LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            // REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x01,                           // REPORT_COUNT (1)
+  D_INPUT, (D_DATA | D_VARIABLE | D_RELATIVE),    // INPUT (Data,Var,Rel)
 
   /* End */
   D_END_COLLECTION                                // END_COLLECTION
@@ -71,7 +71,8 @@ Mouse_::Mouse_() {
 }
 
 void Mouse_::begin() {
-  static HIDSubDescriptor node(mouse_hid_descriptor_, sizeof(mouse_hid_descriptor_));
+  static HIDSubDescriptor node(mouse_hid_descriptor_,
+                               sizeof(mouse_hid_descriptor_));
   HID().AppendDescriptor(&node);
 
   end();
@@ -118,9 +119,10 @@ void Mouse_::sendReportUnchecked() {
 }
 
 void Mouse_::sendReport() {
-  // If the last report is different than the current report, then we need to send a report.
-  // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
-  // if sendReport is called in a tight loop.
+  // If the last report is different than the current report, then we need to
+  // send a report.  We guard sendReport like this so that calling code doesn't
+  // end up spamming the host with empty reports if sendReport is called in a
+  // tight loop.
 
   // if the two reports are the same, check if they're empty, and return early
   // without a report if they are.

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "Mouse.h"
 #include "DescriptorPrimitives.h"
 
-static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
+static const uint8_t mouse_hid_descriptor_[] PROGMEM = {
   /*  Mouse relative */
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
   D_USAGE, D_USAGE_MOUSE,                         //  USAGE (Mouse)
@@ -71,7 +71,7 @@ Mouse_::Mouse_() {
 }
 
 void Mouse_::begin() {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));
+  static HIDSubDescriptor node(mouse_hid_descriptor_, sizeof(mouse_hid_descriptor_));
   HID().AppendDescriptor(&node);
 
   end();
@@ -88,33 +88,33 @@ void Mouse_::click(uint8_t b) {
   release(b);
 }
 
-void Mouse_::move(signed char x, signed char y, signed char vWheel, signed char hWheel) {
-  report.xAxis = x;
-  report.yAxis = y;
-  report.vWheel = vWheel;
-  report.hWheel = hWheel;
+void Mouse_::move(signed char x, signed char y, signed char v_wheel, signed char h_wheel) {
+  report_.xAxis = x;
+  report_.yAxis = y;
+  report_.vWheel = v_wheel;
+  report_.hWheel = h_wheel;
 }
 
 void Mouse_::releaseAll() {
-  memset(&report, 0, sizeof(report));
+  memset(&report_, 0, sizeof(report_));
 }
 
 void Mouse_::press(uint8_t b) {
-  report.buttons |= b;
+  report_.buttons |= b;
 }
 
 void Mouse_::release(uint8_t b) {
-  report.buttons &= ~b;
+  report_.buttons &= ~b;
 }
 
 bool Mouse_::isPressed(uint8_t b) {
-  if ((b & report.buttons) > 0)
+  if ((b & report_.buttons) > 0)
     return true;
   return false;
 }
 
 void Mouse_::sendReportUnchecked() {
-  HID().SendReport(HID_REPORTID_MOUSE, &report, sizeof(report));
+  HID().SendReport(HID_REPORTID_MOUSE, &report_, sizeof(report_));
 }
 
 void Mouse_::sendReport() {
@@ -124,13 +124,13 @@ void Mouse_::sendReport() {
 
   // if the two reports are the same, check if they're empty, and return early
   // without a report if they are.
-  static HID_MouseReport_Data_t emptyReport;
-  if (memcmp(&lastReport, &report, sizeof(report)) == 0 &&
-      memcmp(&report, &emptyReport, sizeof(report)) == 0)
+  static HID_MouseReport_Data_t empty_report;
+  if (memcmp(&last_report_, &report_, sizeof(report_)) == 0 &&
+      memcmp(&report_, &empty_report, sizeof(report_)) == 0)
     return;
 
   sendReportUnchecked();
-  memcpy(&lastReport, &report, sizeof(report));
+  memcpy(&last_report_, &report_, sizeof(report_));
 }
 
 Mouse_ Mouse;

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -89,7 +89,7 @@ void Mouse_::click(uint8_t b) {
   release(b);
 }
 
-void Mouse_::move(signed char x, signed char y, signed char v_wheel, signed char h_wheel) {
+void Mouse_::move(int8_t x, int8_t y, int8_t v_wheel, int8_t h_wheel) {
   report_.xAxis = x;
   report_.yAxis = y;
   report_.vWheel = v_wheel;

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -27,110 +27,110 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
-    /*  Mouse relative */
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
-    D_USAGE, D_USAGE_MOUSE,                         //  USAGE (Mouse)
-    D_COLLECTION, D_APPLICATION,                    //   COLLECTION (Application)
-    D_REPORT_ID, HID_REPORTID_MOUSE,                //    REPORT_ID (Mouse)
+  /*  Mouse relative */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           // USAGE_PAGE (Generic Desktop)
+  D_USAGE, D_USAGE_MOUSE,                         //  USAGE (Mouse)
+  D_COLLECTION, D_APPLICATION,                    //   COLLECTION (Application)
+  D_REPORT_ID, HID_REPORTID_MOUSE,                //    REPORT_ID (Mouse)
 
-    /* 8 Buttons */
-    D_USAGE_PAGE, D_PAGE_BUTTON,                    //    USAGE_PAGE (Button)
-    D_USAGE_MINIMUM, 0x01,                          //     USAGE_MINIMUM (Button 1)
-    D_USAGE_MAXIMUM, 0x08,                          //     USAGE_MAXIMUM (Button 8)
-    D_LOGICAL_MINIMUM, 0x00,                        //     LOGICAL_MINIMUM (0)
-    D_LOGICAL_MAXIMUM, 0x01,                        //     LOGICAL_MAXIMUM (1)
-    D_REPORT_COUNT, 0x08,                           //     REPORT_COUNT (8)
-    D_REPORT_SIZE, 0x01,                            //     REPORT_SIZE (1)
-    D_INPUT, (D_DATA|D_VARIABLE|D_ABSOLUTE),        //     INPUT (Data,Var,Abs)
+  /* 8 Buttons */
+  D_USAGE_PAGE, D_PAGE_BUTTON,                    //    USAGE_PAGE (Button)
+  D_USAGE_MINIMUM, 0x01,                          //     USAGE_MINIMUM (Button 1)
+  D_USAGE_MAXIMUM, 0x08,                          //     USAGE_MAXIMUM (Button 8)
+  D_LOGICAL_MINIMUM, 0x00,                        //     LOGICAL_MINIMUM (0)
+  D_LOGICAL_MAXIMUM, 0x01,                        //     LOGICAL_MAXIMUM (1)
+  D_REPORT_COUNT, 0x08,                           //     REPORT_COUNT (8)
+  D_REPORT_SIZE, 0x01,                            //     REPORT_SIZE (1)
+  D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),    //     INPUT (Data,Var,Abs)
 
-    /* X, Y, Wheel */
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           //    USAGE_PAGE (Generic Desktop)
-    D_USAGE, 0x30,                                  //     USAGE (X)
-    D_USAGE, 0x31,                                  //     USAGE (Y)
-    D_USAGE, 0x38,                                  //     USAGE (Wheel)
-    D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
-    D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
-    D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
-    D_REPORT_COUNT, 0x03,                           //     REPORT_COUNT (3)
-    D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
+  /* X, Y, Wheel */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,           //    USAGE_PAGE (Generic Desktop)
+  D_USAGE, 0x30,                                  //     USAGE (X)
+  D_USAGE, 0x31,                                  //     USAGE (Y)
+  D_USAGE, 0x38,                                  //     USAGE (Wheel)
+  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x03,                           //     REPORT_COUNT (3)
+  D_INPUT, (D_DATA | D_VARIABLE | D_RELATIVE),    //     INPUT (Data,Var,Rel)
 
-    /* Horizontal wheel */
-    D_USAGE_PAGE, D_PAGE_CONSUMER,                  //    USAGE_PAGE (Consumer)
-    D_PAGE_ORDINAL, 0x38, 0x02,                     //     PAGE (AC Pan)
-    D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
-    D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
-    D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
-    D_REPORT_COUNT, 0x01,                           //     REPORT_COUNT (1)
-    D_INPUT, (D_DATA|D_VARIABLE|D_RELATIVE),        //     INPUT (Data,Var,Rel)
+  /* Horizontal wheel */
+  D_USAGE_PAGE, D_PAGE_CONSUMER,                  //    USAGE_PAGE (Consumer)
+  D_PAGE_ORDINAL, 0x38, 0x02,                     //     PAGE (AC Pan)
+  D_LOGICAL_MINIMUM, 0x81,                        //     LOGICAL_MINIMUM (-127)
+  D_LOGICAL_MAXIMUM, 0x7f,                        //     LOGICAL_MAXIMUM (127)
+  D_REPORT_SIZE, 0x08,                            //     REPORT_SIZE (8)
+  D_REPORT_COUNT, 0x01,                           //     REPORT_COUNT (1)
+  D_INPUT, (D_DATA | D_VARIABLE | D_RELATIVE),    //     INPUT (Data,Var,Rel)
 
-    /* End */
-    D_END_COLLECTION                                // END_COLLECTION
+  /* End */
+  D_END_COLLECTION                                // END_COLLECTION
 };
 
 Mouse_::Mouse_(void) {
 }
 
 void Mouse_::begin(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));
-    HID().AppendDescriptor(&node);
+  static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));
+  HID().AppendDescriptor(&node);
 
-    end();
+  end();
 }
 
 void Mouse_::end(void) {
-    releaseAll();
-    sendReport();
+  releaseAll();
+  sendReport();
 }
 
 void Mouse_::click(uint8_t b) {
-    press(b);
-    sendReport();
-    release(b);
+  press(b);
+  sendReport();
+  release(b);
 }
 
 void Mouse_::move(signed char x, signed char y, signed char vWheel, signed char hWheel) {
-    report.xAxis = x;
-    report.yAxis = y;
-    report.vWheel = vWheel;
-    report.hWheel = hWheel;
+  report.xAxis = x;
+  report.yAxis = y;
+  report.vWheel = vWheel;
+  report.hWheel = hWheel;
 }
 
 void Mouse_::releaseAll(void) {
-    memset(&report, 0, sizeof(report));
+  memset(&report, 0, sizeof(report));
 }
 
 void Mouse_::press(uint8_t b) {
-    report.buttons |= b;
+  report.buttons |= b;
 }
 
 void Mouse_::release(uint8_t b) {
-    report.buttons &= ~b;
+  report.buttons &= ~b;
 }
 
 bool Mouse_::isPressed(uint8_t b) {
-    if ((b & report.buttons) > 0)
-        return true;
-    return false;
+  if ((b & report.buttons) > 0)
+    return true;
+  return false;
 }
 
 void Mouse_::sendReportUnchecked(void) {
-    HID().SendReport(HID_REPORTID_MOUSE, &report, sizeof(report));
+  HID().SendReport(HID_REPORTID_MOUSE, &report, sizeof(report));
 }
 
 void Mouse_::sendReport(void) {
-    // If the last report is different than the current report, then we need to send a report.
-    // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
-    // if sendReport is called in a tight loop.
+  // If the last report is different than the current report, then we need to send a report.
+  // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
+  // if sendReport is called in a tight loop.
 
-    // if the two reports are the same, check if they're empty, and return early
-    // without a report if they are.
-    static HID_MouseReport_Data_t emptyReport;
-    if (memcmp(&lastReport, &report, sizeof(report)) == 0 &&
-            memcmp(&report, &emptyReport, sizeof(report)) == 0)
-        return;
+  // if the two reports are the same, check if they're empty, and return early
+  // without a report if they are.
+  static HID_MouseReport_Data_t emptyReport;
+  if (memcmp(&lastReport, &report, sizeof(report)) == 0 &&
+      memcmp(&report, &emptyReport, sizeof(report)) == 0)
+    return;
 
-    sendReportUnchecked();
-    memcpy(&lastReport, &report, sizeof(report));
+  sendReportUnchecked();
+  memcpy(&lastReport, &report, sizeof(report));
 }
 
 Mouse_ Mouse;

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -67,17 +67,17 @@ static const uint8_t _hidMultiReportDescriptorMouse[] PROGMEM = {
   D_END_COLLECTION                                // END_COLLECTION
 };
 
-Mouse_::Mouse_(void) {
+Mouse_::Mouse_() {
 }
 
-void Mouse_::begin(void) {
+void Mouse_::begin() {
   static HIDSubDescriptor node(_hidMultiReportDescriptorMouse, sizeof(_hidMultiReportDescriptorMouse));
   HID().AppendDescriptor(&node);
 
   end();
 }
 
-void Mouse_::end(void) {
+void Mouse_::end() {
   releaseAll();
   sendReport();
 }
@@ -95,7 +95,7 @@ void Mouse_::move(signed char x, signed char y, signed char vWheel, signed char 
   report.hWheel = hWheel;
 }
 
-void Mouse_::releaseAll(void) {
+void Mouse_::releaseAll() {
   memset(&report, 0, sizeof(report));
 }
 
@@ -113,11 +113,11 @@ bool Mouse_::isPressed(uint8_t b) {
   return false;
 }
 
-void Mouse_::sendReportUnchecked(void) {
+void Mouse_::sendReportUnchecked() {
   HID().SendReport(HID_REPORTID_MOUSE, &report, sizeof(report));
 }
 
-void Mouse_::sendReport(void) {
+void Mouse_::sendReport() {
   // If the last report is different than the current report, then we need to send a report.
   // We guard sendReport like this so that calling code doesn't end up spamming the host with empty reports
   // if sendReport is called in a tight loop.

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -32,46 +32,46 @@ THE SOFTWARE.
 #include "../MouseButtons.h"
 
 typedef union {
-    // Mouse report: 8 buttons, position, wheel
-    struct {
-        uint8_t buttons;
-        int8_t xAxis;
-        int8_t yAxis;
-        int8_t vWheel;
-        int8_t hWheel;
-    };
+  // Mouse report: 8 buttons, position, wheel
+  struct {
+    uint8_t buttons;
+    int8_t xAxis;
+    int8_t yAxis;
+    int8_t vWheel;
+    int8_t hWheel;
+  };
 } HID_MouseReport_Data_t;
 
 
 class Mouse_ {
-  public:
-    Mouse_(void);
-    void begin(void);
-    void end(void);
-    void click(uint8_t b = MOUSE_LEFT);
-    void move(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
-    void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
-    void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
-    bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default
+ public:
+  Mouse_(void);
+  void begin(void);
+  void end(void);
+  void click(uint8_t b = MOUSE_LEFT);
+  void move(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
+  void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
+  void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
+  bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default
 
-    /** getReport returns the current report.
-     *
-     * The current report is the one to be send next time sendReport() is called.
-     *
-     * @returns A copy of the report.
-     */
-    const HID_MouseReport_Data_t getReport() {
-        return report;
-    }
-    void sendReport(void);
+  /** getReport returns the current report.
+   *
+   * The current report is the one to be send next time sendReport() is called.
+   *
+   * @returns A copy of the report.
+   */
+  const HID_MouseReport_Data_t getReport() {
+    return report;
+  }
+  void sendReport(void);
 
-    void releaseAll(void);
+  void releaseAll(void);
 
-  protected:
-    HID_MouseReport_Data_t report;
-    HID_MouseReport_Data_t lastReport;
+ protected:
+  HID_MouseReport_Data_t report;
+  HID_MouseReport_Data_t lastReport;
 
-  private:
-    void sendReportUnchecked(void);
+ private:
+  void sendReportUnchecked(void);
 };
 extern Mouse_ Mouse;

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -45,9 +45,9 @@ typedef union {
 
 class Mouse_ {
  public:
-  Mouse_(void);
-  void begin(void);
-  void end(void);
+  Mouse_();
+  void begin();
+  void end();
   void click(uint8_t b = MOUSE_LEFT);
   void move(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
   void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
@@ -63,15 +63,15 @@ class Mouse_ {
   const HID_MouseReport_Data_t getReport() {
     return report;
   }
-  void sendReport(void);
+  void sendReport();
 
-  void releaseAll(void);
+  void releaseAll();
 
  protected:
   HID_MouseReport_Data_t report;
   HID_MouseReport_Data_t lastReport;
 
  private:
-  void sendReportUnchecked(void);
+  void sendReportUnchecked();
 };
 extern Mouse_ Mouse;

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -49,7 +49,7 @@ class Mouse_ {
   void begin();
   void end();
   void click(uint8_t b = MOUSE_LEFT);
-  void move(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
+  void move(signed char x, signed char y, signed char v_wheel = 0, signed char h_wheel = 0);
   void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
   void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
   bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default
@@ -61,15 +61,15 @@ class Mouse_ {
    * @returns A copy of the report.
    */
   const HID_MouseReport_Data_t getReport() {
-    return report;
+    return report_;
   }
   void sendReport();
 
   void releaseAll();
 
  protected:
-  HID_MouseReport_Data_t report;
-  HID_MouseReport_Data_t lastReport;
+  HID_MouseReport_Data_t report_;
+  HID_MouseReport_Data_t last_report_;
 
  private:
   void sendReportUnchecked();

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -49,7 +49,7 @@ class Mouse_ {
   void begin();
   void end();
   void click(uint8_t b = MOUSE_LEFT);
-  void move(signed char x, signed char y, signed char v_wheel = 0, signed char h_wheel = 0);
+  void move(int8_t x, int8_t y, int8_t v_wheel = 0, int8_t h_wheel = 0);
   void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default
   void release(uint8_t b = MOUSE_LEFT); // release LEFT by default
   bool isPressed(uint8_t b = MOUSE_LEFT); // check LEFT by default

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -29,23 +29,24 @@ THE SOFTWARE.
 static const uint8_t system_control_hid_descriptor_[] PROGMEM = {
   //TODO limit to system keys only?
   /*  System Control (Power Down, Sleep, Wakeup, ...) */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,								/* USAGE_PAGE (Generic Desktop) */
-  D_USAGE, 0x80,								/* USAGE (System Control) */
-  D_COLLECTION, D_APPLICATION, 							/* COLLECTION (Application) */
-  D_REPORT_ID, HID_REPORTID_SYSTEMCONTROL,		/* REPORT_ID */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x80,				/* USAGE (System Control) */
+  D_COLLECTION, D_APPLICATION, 			/* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_SYSTEMCONTROL,	/* REPORT_ID */
   /* 1 system key */
-  D_LOGICAL_MINIMUM, 0x00, 							/* LOGICAL_MINIMUM (0) */
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xff, 0x00, 						/* LOGICAL_MAXIMUM (255) */
-  D_USAGE_MINIMUM, 0x00, 							/* USAGE_MINIMUM (Undefined) */
-  D_USAGE_MAXIMUM, 0xff, 							/* USAGE_MAXIMUM (System Menu Down) */
-  D_REPORT_COUNT, 0x01, 							/* REPORT_COUNT (1) */
-  D_REPORT_SIZE, 0x08, 							/* REPORT_SIZE (8) */
-  D_INPUT, (D_DATA | D_ARRAY | D_ABSOLUTE), 							/* INPUT (Data,Ary,Abs) */
-  D_END_COLLECTION 									/* END_COLLECTION */
+  D_LOGICAL_MINIMUM, 0x00, 			/* LOGICAL_MINIMUM (0) */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xff, 0x00, 	/* LOGICAL_MAXIMUM (255) */
+  D_USAGE_MINIMUM, 0x00, 			/* USAGE_MINIMUM (Undefined) */
+  D_USAGE_MAXIMUM, 0xff, 			/* USAGE_MAXIMUM (System Menu Down) */
+  D_REPORT_COUNT, 0x01, 			/* REPORT_COUNT (1) */
+  D_REPORT_SIZE, 0x08, 				/* REPORT_SIZE (8) */
+  D_INPUT, (D_DATA | D_ARRAY | D_ABSOLUTE), 	/* INPUT (Data,Ary,Abs) */
+  D_END_COLLECTION 				/* END_COLLECTION */
 };
 
 SystemControl_::SystemControl_() {
-  static HIDSubDescriptor node(system_control_hid_descriptor_, sizeof(system_control_hid_descriptor_));
+  static HIDSubDescriptor node(system_control_hid_descriptor_,
+                               sizeof(system_control_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -44,17 +44,17 @@ static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
   D_END_COLLECTION 									/* END_COLLECTION */
 };
 
-SystemControl_::SystemControl_(void) {
+SystemControl_::SystemControl_() {
   static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
   HID().AppendDescriptor(&node);
 }
 
-void SystemControl_::begin(void) {
+void SystemControl_::begin() {
   // release all buttons
   end();
 }
 
-void SystemControl_::end(void) {
+void SystemControl_::end() {
   uint8_t _report = 0x00;
   sendReport(&_report, sizeof(_report));
 }
@@ -64,11 +64,11 @@ void SystemControl_::write(uint8_t s) {
   release();
 }
 
-void SystemControl_::release(void) {
+void SystemControl_::release() {
   begin();
 }
 
-void SystemControl_::releaseAll(void) {
+void SystemControl_::releaseAll() {
   begin();
 }
 

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -27,70 +27,70 @@ THE SOFTWARE.
 #include "DescriptorPrimitives.h"
 
 static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
-    //TODO limit to system keys only?
-    /*  System Control (Power Down, Sleep, Wakeup, ...) */
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,								/* USAGE_PAGE (Generic Desktop) */
-    D_USAGE, 0x80,								/* USAGE (System Control) */
-    D_COLLECTION, D_APPLICATION, 							/* COLLECTION (Application) */
-    D_REPORT_ID, HID_REPORTID_SYSTEMCONTROL,		/* REPORT_ID */
-    /* 1 system key */
-    D_LOGICAL_MINIMUM, 0x00, 							/* LOGICAL_MINIMUM (0) */
-    D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xff, 0x00, 						/* LOGICAL_MAXIMUM (255) */
-    D_USAGE_MINIMUM, 0x00, 							/* USAGE_MINIMUM (Undefined) */
-    D_USAGE_MAXIMUM, 0xff, 							/* USAGE_MAXIMUM (System Menu Down) */
-    D_REPORT_COUNT, 0x01, 							/* REPORT_COUNT (1) */
-    D_REPORT_SIZE, 0x08, 							/* REPORT_SIZE (8) */
-    D_INPUT, (D_DATA|D_ARRAY|D_ABSOLUTE), 							/* INPUT (Data,Ary,Abs) */
-    D_END_COLLECTION 									/* END_COLLECTION */
+  //TODO limit to system keys only?
+  /*  System Control (Power Down, Sleep, Wakeup, ...) */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,								/* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x80,								/* USAGE (System Control) */
+  D_COLLECTION, D_APPLICATION, 							/* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_SYSTEMCONTROL,		/* REPORT_ID */
+  /* 1 system key */
+  D_LOGICAL_MINIMUM, 0x00, 							/* LOGICAL_MINIMUM (0) */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xff, 0x00, 						/* LOGICAL_MAXIMUM (255) */
+  D_USAGE_MINIMUM, 0x00, 							/* USAGE_MINIMUM (Undefined) */
+  D_USAGE_MAXIMUM, 0xff, 							/* USAGE_MAXIMUM (System Menu Down) */
+  D_REPORT_COUNT, 0x01, 							/* REPORT_COUNT (1) */
+  D_REPORT_SIZE, 0x08, 							/* REPORT_SIZE (8) */
+  D_INPUT, (D_DATA | D_ARRAY | D_ABSOLUTE), 							/* INPUT (Data,Ary,Abs) */
+  D_END_COLLECTION 									/* END_COLLECTION */
 };
 
 SystemControl_::SystemControl_(void) {
-    static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
-    HID().AppendDescriptor(&node);
+  static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
+  HID().AppendDescriptor(&node);
 }
 
 void SystemControl_::begin(void) {
-    // release all buttons
-    end();
+  // release all buttons
+  end();
 }
 
 void SystemControl_::end(void) {
-    uint8_t _report = 0x00;
-    sendReport(&_report, sizeof(_report));
+  uint8_t _report = 0x00;
+  sendReport(&_report, sizeof(_report));
 }
 
 void SystemControl_::write(uint8_t s) {
-    press(s);
-    release();
+  press(s);
+  release();
 }
 
 void SystemControl_::release(void) {
-    begin();
+  begin();
 }
 
 void SystemControl_::releaseAll(void) {
-    begin();
+  begin();
 }
 
 void SystemControl_::press(uint8_t s) {
-    if (s == HID_SYSTEM_WAKE_UP) {
+  if (s == HID_SYSTEM_WAKE_UP) {
 #ifdef __AVR__
-        USBDevice.wakeupHost();
+    USBDevice.wakeupHost();
 #endif
 #ifdef ARDUINO_ARCH_SAMD
-        // This is USBDevice_SAMD21G18x.wakeupHost(). But we can't include that
-        // header, because it redefines a few symbols, and causes linking
-        // errors. So we simply reimplement the same thing here.
-        USB->DEVICE.CTRLB.bit.UPRSM = 1;
+    // This is USBDevice_SAMD21G18x.wakeupHost(). But we can't include that
+    // header, because it redefines a few symbols, and causes linking
+    // errors. So we simply reimplement the same thing here.
+    USB->DEVICE.CTRLB.bit.UPRSM = 1;
 #endif
-    } else {
-        sendReport(&s, sizeof(s));
-    }
+  } else {
+    sendReport(&s, sizeof(s));
+  }
 }
 
 
 void SystemControl_::sendReport(void* data, int length) {
-    HID().SendReport(HID_REPORTID_SYSTEMCONTROL, data, length);
+  HID().SendReport(HID_REPORTID_SYSTEMCONTROL, data, length);
 }
 
 SystemControl_ SystemControl;

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "SystemControl.h"
 #include "DescriptorPrimitives.h"
 
-static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
+static const uint8_t system_control_hid_descriptor_[] PROGMEM = {
   //TODO limit to system keys only?
   /*  System Control (Power Down, Sleep, Wakeup, ...) */
   D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,								/* USAGE_PAGE (Generic Desktop) */
@@ -45,7 +45,7 @@ static const uint8_t _hidMultiReportDescriptorSystem[] PROGMEM = {
 };
 
 SystemControl_::SystemControl_() {
-  static HIDSubDescriptor node(_hidMultiReportDescriptorSystem, sizeof(_hidMultiReportDescriptorSystem));
+  static HIDSubDescriptor node(system_control_hid_descriptor_, sizeof(system_control_hid_descriptor_));
   HID().AppendDescriptor(&node);
 }
 
@@ -55,8 +55,8 @@ void SystemControl_::begin() {
 }
 
 void SystemControl_::end() {
-  uint8_t _report = 0x00;
-  sendReport(&_report, sizeof(_report));
+  uint8_t report = 0x00;
+  sendReport(&report, sizeof(report));
 }
 
 void SystemControl_::write(uint8_t s) {

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -29,19 +29,19 @@ THE SOFTWARE.
 static const uint8_t system_control_hid_descriptor_[] PROGMEM = {
   //TODO limit to system keys only?
   /*  System Control (Power Down, Sleep, Wakeup, ...) */
-  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,		/* USAGE_PAGE (Generic Desktop) */
-  D_USAGE, 0x80,				/* USAGE (System Control) */
-  D_COLLECTION, D_APPLICATION, 			/* COLLECTION (Application) */
-  D_REPORT_ID, HID_REPORTID_SYSTEMCONTROL,	/* REPORT_ID */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop) */
+  D_USAGE, 0x80,                                /* USAGE (System Control) */
+  D_COLLECTION, D_APPLICATION,                  /* COLLECTION (Application) */
+  D_REPORT_ID, HID_REPORTID_SYSTEMCONTROL,      /* REPORT_ID */
   /* 1 system key */
-  D_LOGICAL_MINIMUM, 0x00, 			/* LOGICAL_MINIMUM (0) */
-  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xff, 0x00, 	/* LOGICAL_MAXIMUM (255) */
-  D_USAGE_MINIMUM, 0x00, 			/* USAGE_MINIMUM (Undefined) */
-  D_USAGE_MAXIMUM, 0xff, 			/* USAGE_MAXIMUM (System Menu Down) */
-  D_REPORT_COUNT, 0x01, 			/* REPORT_COUNT (1) */
-  D_REPORT_SIZE, 0x08, 				/* REPORT_SIZE (8) */
-  D_INPUT, (D_DATA | D_ARRAY | D_ABSOLUTE), 	/* INPUT (Data,Ary,Abs) */
-  D_END_COLLECTION 				/* END_COLLECTION */
+  D_LOGICAL_MINIMUM, 0x00,                      /* LOGICAL_MINIMUM (0) */
+  D_MULTIBYTE(D_LOGICAL_MAXIMUM), 0xff, 0x00,   /* LOGICAL_MAXIMUM (255) */
+  D_USAGE_MINIMUM, 0x00,                        /* USAGE_MINIMUM (Undefined) */
+  D_USAGE_MAXIMUM, 0xff,                        /* USAGE_MAXIMUM (System Menu Down) */
+  D_REPORT_COUNT, 0x01,                         /* REPORT_COUNT (1) */
+  D_REPORT_SIZE, 0x08,                          /* REPORT_SIZE (8) */
+  D_INPUT, (D_DATA | D_ARRAY | D_ABSOLUTE),     /* INPUT (Data,Ary,Abs) */
+  D_END_COLLECTION                              /* END_COLLECTION */
 };
 
 SystemControl_::SystemControl_() {

--- a/src/MultiReport/SystemControl.h
+++ b/src/MultiReport/SystemControl.h
@@ -39,15 +39,15 @@ typedef union {
 
 class SystemControl_ {
  public:
-  void begin(void);
-  void end(void);
+  void begin();
+  void end();
   void write(uint8_t s);
   void press(uint8_t s);
-  void release(void);
-  void releaseAll(void);
+  void release();
+  void releaseAll();
   void sendReport(void* data, int length);
 
-  SystemControl_(void);
+  SystemControl_();
 
  protected:
 };

--- a/src/MultiReport/SystemControl.h
+++ b/src/MultiReport/SystemControl.h
@@ -32,24 +32,24 @@ THE SOFTWARE.
 #include "HIDTables.h"
 
 typedef union {
-    // Every usable system control key possible
-    uint8_t key;
+  // Every usable system control key possible
+  uint8_t key;
 } HID_SystemControlReport_Data_t;
 
 
 class SystemControl_ {
-  public:
-    void begin(void);
-    void end(void);
-    void write(uint8_t s);
-    void press(uint8_t s);
-    void release(void);
-    void releaseAll(void);
-    void sendReport(void* data, int length);
+ public:
+  void begin(void);
+  void end(void);
+  void write(uint8_t s);
+  void press(uint8_t s);
+  void release(void);
+  void releaseAll(void);
+  void sendReport(void* data, int length);
 
-    SystemControl_(void);
+  SystemControl_(void);
 
-  protected:
+ protected:
 };
 
 

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -38,7 +38,7 @@ static const uint8_t _hidSingleReportDescriptorAbsoluteMouse[] PROGMEM = {
 };
 
 
-SingleAbsoluteMouse_::SingleAbsoluteMouse_(void) : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1) {
+SingleAbsoluteMouse_::SingleAbsoluteMouse_() : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1) {
   epType[0] = EP_TYPE_INTERRUPT_IN;
   PluggableUSB().plug(this);
 }

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -27,91 +27,91 @@ THE SOFTWARE.
 #include "HIDReportObserver.h"
 
 static const uint8_t _hidSingleReportDescriptorAbsoluteMouse[] PROGMEM = {
-    D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)         54 */
-    D_USAGE, D_USAGE_MOUSE,                             /* USAGE (Mouse) */
-    D_COLLECTION, D_APPLICATION,                        /* COLLECTION (Application) */
+  D_USAGE_PAGE, D_PAGE_GENERIC_DESKTOP,         /* USAGE_PAGE (Generic Desktop)         54 */
+  D_USAGE, D_USAGE_MOUSE,                             /* USAGE (Mouse) */
+  D_COLLECTION, D_APPLICATION,                        /* COLLECTION (Application) */
 
-    DESCRIPTOR_ABS_MOUSE_BUTTONS
-    DESCRIPTOR_ABS_MOUSE_XY
-    DESCRIPTOR_ABS_MOUSE_WHEEL
-    D_END_COLLECTION                             /* End */
+  DESCRIPTOR_ABS_MOUSE_BUTTONS
+  DESCRIPTOR_ABS_MOUSE_XY
+  DESCRIPTOR_ABS_MOUSE_WHEEL
+  D_END_COLLECTION                             /* End */
 };
 
 
 SingleAbsoluteMouse_::SingleAbsoluteMouse_(void) : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1) {
-    epType[0] = EP_TYPE_INTERRUPT_IN;
-    PluggableUSB().plug(this);
+  epType[0] = EP_TYPE_INTERRUPT_IN;
+  PluggableUSB().plug(this);
 }
 
 int SingleAbsoluteMouse_::getInterface(uint8_t* interfaceCount) {
-    *interfaceCount += 1; // uses 1
-    HIDDescriptor hidInterface = {
-        D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
-        D_HIDREPORT(sizeof(_hidSingleReportDescriptorAbsoluteMouse)),
-        D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
-    };
-    return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
+  *interfaceCount += 1; // uses 1
+  HIDDescriptor hidInterface = {
+    D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
+    D_HIDREPORT(sizeof(_hidSingleReportDescriptorAbsoluteMouse)),
+    D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
+  };
+  return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
 int SingleAbsoluteMouse_::getDescriptor(USBSetup& setup) {
-    // Check if this is a HID Class Descriptor request
-    if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
-        return 0;
-    }
-    if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) {
-        return 0;
-    }
+  // Check if this is a HID Class Descriptor request
+  if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
+    return 0;
+  }
+  if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) {
+    return 0;
+  }
 
-    // In a HID Class Descriptor wIndex cointains the interface number
-    if (setup.wIndex != pluggedInterface) {
-        return 0;
-    }
+  // In a HID Class Descriptor wIndex cointains the interface number
+  if (setup.wIndex != pluggedInterface) {
+    return 0;
+  }
 
-    // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-    // due to the USB specs, but Windows and Linux just assumes its in report mode.
-    protocol = HID_REPORT_PROTOCOL;
+  // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+  // due to the USB specs, but Windows and Linux just assumes its in report mode.
+  protocol = HID_REPORT_PROTOCOL;
 
-    return USB_SendControl(TRANSFER_PGM, _hidSingleReportDescriptorAbsoluteMouse, sizeof(_hidSingleReportDescriptorAbsoluteMouse));
+  return USB_SendControl(TRANSFER_PGM, _hidSingleReportDescriptorAbsoluteMouse, sizeof(_hidSingleReportDescriptorAbsoluteMouse));
 }
 
 bool SingleAbsoluteMouse_::setup(USBSetup& setup) {
-    if (pluggedInterface != setup.wIndex) {
-        return false;
-    }
-
-    uint8_t request = setup.bRequest;
-    uint8_t requestType = setup.bmRequestType;
-
-    if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE) {
-        if (request == HID_GET_REPORT) {
-            // TODO: HID_GetReport();
-            return true;
-        }
-        if (request == HID_GET_PROTOCOL) {
-            // TODO: Send8(protocol);
-            return true;
-        }
-    }
-
-    if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
-        if (request == HID_SET_PROTOCOL) {
-            protocol = setup.wValueL;
-            return true;
-        }
-        if (request == HID_SET_IDLE) {
-            idle = setup.wValueL;
-            return true;
-        }
-        if (request == HID_SET_REPORT) {
-        }
-    }
-
+  if (pluggedInterface != setup.wIndex) {
     return false;
+  }
+
+  uint8_t request = setup.bRequest;
+  uint8_t requestType = setup.bmRequestType;
+
+  if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE) {
+    if (request == HID_GET_REPORT) {
+      // TODO: HID_GetReport();
+      return true;
+    }
+    if (request == HID_GET_PROTOCOL) {
+      // TODO: Send8(protocol);
+      return true;
+    }
+  }
+
+  if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
+    if (request == HID_SET_PROTOCOL) {
+      protocol = setup.wValueL;
+      return true;
+    }
+    if (request == HID_SET_IDLE) {
+      idle = setup.wValueL;
+      return true;
+    }
+    if (request == HID_SET_REPORT) {
+    }
+  }
+
+  return false;
 }
 
 void SingleAbsoluteMouse_::sendReport(void* data, int length) {
-    auto result = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
-    HIDReportObserver::observeReport(HID_REPORTID_MOUSE_ABSOLUTE, data, length, result);
+  auto result = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
+  HIDReportObserver::observeReport(HID_REPORTID_MOUSE_ABSOLUTE, data, length, result);
 }
 
 SingleAbsoluteMouse_ SingleAbsoluteMouse;

--- a/src/SingleReport/SingleAbsoluteMouse.h
+++ b/src/SingleReport/SingleAbsoluteMouse.h
@@ -33,21 +33,21 @@ THE SOFTWARE.
 
 
 class SingleAbsoluteMouse_ : public PluggableUSBModule, public AbsoluteMouseAPI {
-  public:
-    SingleAbsoluteMouse_(void);
-    uint8_t getLeds(void);
-    uint8_t getProtocol(void);
+ public:
+  SingleAbsoluteMouse_(void);
+  uint8_t getLeds(void);
+  uint8_t getProtocol(void);
 
-  protected:
-    // Implementation of the PUSBListNode
-    int getInterface(uint8_t* interfaceCount);
-    int getDescriptor(USBSetup& setup);
-    bool setup(USBSetup& setup);
+ protected:
+  // Implementation of the PUSBListNode
+  int getInterface(uint8_t* interfaceCount);
+  int getDescriptor(USBSetup& setup);
+  bool setup(USBSetup& setup);
 
-    EPTYPE_DESCRIPTOR_SIZE epType[1];
-    uint8_t protocol;
-    uint8_t idle;
+  EPTYPE_DESCRIPTOR_SIZE epType[1];
+  uint8_t protocol;
+  uint8_t idle;
 
-    virtual inline void sendReport(void* data, int length) override;
+  virtual inline void sendReport(void* data, int length) override;
 };
 extern SingleAbsoluteMouse_ SingleAbsoluteMouse;

--- a/src/SingleReport/SingleAbsoluteMouse.h
+++ b/src/SingleReport/SingleAbsoluteMouse.h
@@ -34,9 +34,9 @@ THE SOFTWARE.
 
 class SingleAbsoluteMouse_ : public PluggableUSBModule, public AbsoluteMouseAPI {
  public:
-  SingleAbsoluteMouse_(void);
-  uint8_t getLeds(void);
-  uint8_t getProtocol(void);
+  SingleAbsoluteMouse_();
+  uint8_t getLeds();
+  uint8_t getProtocol();
 
  protected:
   // Implementation of the PUSBListNode

--- a/src/arch/samd.cpp
+++ b/src/arch/samd.cpp
@@ -3,11 +3,11 @@
 #ifdef ARDUINO_ARCH_SAMD
 
 int USB_SendControl(void* b, unsigned char c) {
-    USBDevice.sendControl(b, c);
+  USBDevice.sendControl(b, c);
 }
 
 int USB_SendControl(uint8_t a, const void* b, uint8_t c) {
-    USBDevice.sendControl(b, c);
+  USBDevice.sendControl(b, c);
 }
 
 void USB_PackMessages(bool pack) {


### PR DESCRIPTION
This updates the code in KeyboardioHID to (roughly) use the coding style of Kaleidoscope. In a few places, I didn't bother, and in some cases, it wasn't possible (because of the interface with Arduino code).

Notably, I changed the `make astyle` target to call astyle with the same options used in Kaleidoscope, via a `.astylerc` file and the `--project` option. Other than that, there should be no code changes other than refactoring variable names.