### PR TITLE
Improve handling of simultaneous changes in a single NKRO report

### DIFF
--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -95,59 +95,77 @@ void Keyboard_::end() {
 }
 
 int Keyboard_::sendReportUnchecked() {
-  return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &report_, sizeof(report_));
+  return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD,
+                          &last_report_, sizeof(last_report_));
 }
 
+// Sending the current HID report to the host:
+//
+// Depending on the differences between the current and previous HID reports, we
+// might need to send one or two extra reports to guarantee that the host will
+// process the changes in the correct order. There are two important scenarios
+// to consider:
+//
+// 1. If a non-modifier keycode toggles off in the same report as a modifier
+// changes, the host might process the modifier change first. For example, if
+// both `shift` and `4` toggle off in the same report (most likely from a
+// `LSHIFT(Key_4)` key being released), and that key has been held long enough
+// to trigger character repeat, we could end up with a plain `4` in the output
+// at the end of the repeat: `$$$$4` instead of `$$$$$`.
+//
+// 2. If a non-modifier keycode toggles on in the same report as a modifier
+// changes, the host might process the non-modifer first. For example, pressing
+// and holding an `LSHIFT(Key_4)` key might result in `4$$$` rather than `$$$$`.
+//
+// Therefore, each call to `sendReport()` must send (up to) three reports to the
+// host to guarantee the correct order of processing:
+//
+// 1. A report with toggled-off non-modifiers removed.
+// 2. A report with changes to modifiers.
+// 3. A report with toggled-on non-modifiers added.
 
 int Keyboard_::sendReport() {
-  // If the last report is different than the current report, then we need to
-  // send a report.  We guard sendReport like this so that calling code doesn't
-  // end up spamming the host with empty reports if sendReport is called in a
-  // tight loop.
+  // If the new HID report differs from the previous one both in active modifier
+  // keycodes and non-modifier keycodes, we will need to send at least one extra
+  // report. First, we compare the modifiers bytes of the two reports.
+  const uint8_t old_modifiers = last_report_.modifiers;
+  const uint8_t new_modifiers = report_.modifiers;
 
-  if (memcmp(last_report_.allkeys, report_.allkeys, sizeof(report_))) {
-    // if the two reports are different, send a report
+  const uint8_t changed_modifiers = old_modifiers ^ new_modifiers;
 
-    // ChromeOS 51-60 (at least) bug: if a modifier and a normal keycode are
-    // added in the same report, in some cases the shift is not applied
-    // (e.g. `shift`+`[` doesn't yield `{`). To compensate for this, check to
-    // see if the modifier byte has changed.
-
-    // If modifiers are being turned on at the same time as any change to the
-    // non-modifier keys in the report, then we send the previous report with
-    // the new modifiers
-    if (((last_report_.modifiers ^ report_.modifiers) & report_.modifiers)
-        && (memcmp(last_report_.keys, report_.keys, sizeof(report_.keys)))) {
-      uint8_t last_mods = last_report_.modifiers;
-      last_report_.modifiers = report_.modifiers;
-      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD,
-                                        &last_report_, sizeof(last_report_));
-      last_report_.modifiers = last_mods;
+  if (changed_modifiers != 0) {
+    // There was at least one modifier change (toggled on or off), remove any
+    // non-modifiers from the stored previous report that toggled off in the new
+    // report, and send it to the host.
+    bool non_modifiers_toggled_off = false;
+    for (uint8_t i = 0; i < KEY_BYTES; ++i) {
+      byte released_keycodes = last_report_.keys[i] & ~(report_.keys[i]);
+      if (released_keycodes != 0) {
+        last_report_.keys[i] &= ~released_keycodes;
+        non_modifiers_toggled_off = true;
+      }
     }
-
-    // If modifiers are being turned off, then we send the new report with the
-    // previous modifiers.  We need to do this, at least on Linux 4.17 +
-    // Wayland.  Jesse has observed that sending Shift + 3 key up events in the
-    // same report will sometimes result in a spurious '3' rather than '#',
-    // especially when the keys had been held for a while
-    else if (((last_report_.modifiers ^ report_.modifiers) & last_report_.modifiers)
-             && (memcmp(last_report_.keys, report_.keys, sizeof(report_.keys)))) {
-      uint8_t mods = report_.modifiers;
-      report_.modifiers = last_report_.modifiers;
-      int returnCode = HID().SendReport(HID_REPORTID_NKRO_KEYBOARD,
-                                        &report_, sizeof(last_report_));
-      report_.modifiers = mods;
+    if (non_modifiers_toggled_off) {
+      sendReportUnchecked();
     }
-
-
-
-
-
-    int returnCode = sendReportUnchecked();
-    if (returnCode > 0)
-      memcpy(last_report_.allkeys, report_.allkeys, sizeof(report_));
-    return returnCode;
+    // Next, update the modifiers byte of the stored previous report, and send
+    // it.
+    last_report_.modifiers = new_modifiers;
+    sendReportUnchecked();
   }
+
+  // Finally, copy the new report to the previous one, and send it.
+  if (memcmp(last_report_.keys, report_.keys, sizeof(report_.keys)) != 0) {
+    memcpy(last_report_.keys, report_.keys, sizeof(report_.keys));
+    return sendReportUnchecked();
+  }
+  // A note on return values: Kaleidoscope doesn't actually check the return
+  // value of `sendReport()`, so this function could be changed to return
+  // void. It would be nice if we could do something to recover from an error
+  // here, but it's not at all clear what that should be. Also note that if the
+  // extra reports above return an error, there's not much we can do to try to
+  // recover. We could try to send the report again, but that would be likely to
+  // fail as well.
   return -1;
 }
 

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -67,8 +67,8 @@ class Keyboard_ {
     return HID().getLEDs();
   };
 
-  HID_KeyboardReport_Data_t report_;
-  HID_KeyboardReport_Data_t last_report_;
+  HID_KeyboardReport_Data_t pending_report_;
+  HID_KeyboardReport_Data_t current_report_;
  private:
   int sendReportUnchecked();
 };


### PR DESCRIPTION
When `sendReport()` is called, it now first checks for changes in the modifiers byte, and breaks down the process of transitioning to the new report into three stages:

1. First, any non-modifier keycodes that toggled off are removed from the old report, if any, and a report is (conditionally) sent. This ensures that a key with a modifier flag attached that toggles off won't have the host process the modifier first, potentially causing a erroneous repeat character. For example, if `LSHIFT(Key_4)` is held and released, we need to first send a report without the `4`, or some hosts will process the release of `shift` first, and give us `$$$4` in the output instead of `$$$$`.

2. Second, the modifiers that toggled on and/or off are updated, and a report is sent. This handles the situation where a key with a modifier flag toggles on, and we need to ensure that the host will process the modifier first to prevent erroneous output on the first character (`4$$$` vs `$$$$`).

3. Last, if there are any non-modifier keycodes that toggled on, they are added to the old report, and the final report is sent.

To accomplish this, the old report is modified in each step, and `sendReportUnchecked()` sends the contents of that (modified) old report rather than the new one. We could avoid that by making a temporary copy of the old report, and updating and sending that instead, but there isn't much point to doing so because there isn't any reasonable way for us to recover from errors. Kaleidoscope doesn't even check the return value when calling `sendReport()`, and it's not clear what we should do if an error occurs, anyway.

This new way of handling simultaneous changes from one report to the next covers more cases than the old way, which would never send both extra reports and failed to cover cases where a modifier toggles off when a non-modifier keycode toggles on (something that happens with the TopsyTurvy plugin), or where a modifier toggles on in the same report as a non-modifier toggles off (also possible with TopsyTurvy).