### PR TITLE
Make Keyboard HID report data variables private

### DIFF
--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -67,9 +67,10 @@ class Keyboard_ {
     return HID().getLEDs();
   };
 
+ private:
   HID_KeyboardReport_Data_t report_;
   HID_KeyboardReport_Data_t last_report_;
- private:
+
   int sendReportUnchecked();
 };
 extern Keyboard_ Keyboard;


### PR DESCRIPTION
These were originally made public at my request in order to (imperfectly) work around a mid-cycle report problem in Qukeys.  That problem was that, if a plugin wanted to send one or more extra reports in response to a keyswitch toggling on or off, it was not possible to safely send such a report from an `onKeyswitchEvent()` handler, because the new report was likely incomplete.  The workaround was to give plugins direct access to the old report's data structure, which could then be modified and sent. This wasn't a good solution, however, because of potentially complex plugin interactions.

That workaround has since been replaced with a system that only sends reports in another handler function (`beforeReportingState()` or `afterEachCycle()`).  This works, and while it creates more complexity, it solves the problem without requiring direct access to the report data, and better avoids potential bugs.

In addition, if/when keyboardio/Kaleidoscope#1024 is merged, the whole reason for making these public in the first place becomes moot, because then it becomes perfectly safe for plugins to send those extra reports at any time in the cycle.