### PR TITLE
Fix HID_SET_IDLE

### DIFF
--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -152,7 +152,7 @@ bool HID_::setup(USBSetup& setup) {
       return true;
     }
     if (request == HID_SET_IDLE) {
-      idle = setup.wValueL;
+      idle = setup.wValueH;
       return true;
     }
     if (request == HID_SET_REPORT) {


### PR DESCRIPTION
Based on arduino/ArduinoCore-avr#422, we need to use `wValueH` rather than `wValueL` when handling the `HID_SET_IDLE` request, according to the USB spec.

Fixes #71.
