### PR TITLE
BootKeyboard: Reorganize how the default protocol can be set

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -73,8 +73,9 @@ static const uint8_t boot_keyboard_hid_descriptor_[] PROGMEM = {
   D_END_COLLECTION
 };
 
-BootKeyboard_::BootKeyboard_() : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1), leds(0) {
+BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), protocol(protocol_), default_protocol(protocol_), idle(1), leds(0) {
   epType[0] = EP_TYPE_INTERRUPT_IN;
+  PluggableUSB().plug(this);
 }
 
 int BootKeyboard_::getInterface(uint8_t* interfaceCount) {
@@ -110,8 +111,6 @@ int BootKeyboard_::getDescriptor(USBSetup& setup) {
 
 
 void BootKeyboard_::begin() {
-  PluggableUSB().plug(this);
-
   // Force API to send a clean report.
   // This is important for and HID bridge where the receiver stays on,
   // while the sender is resetted.
@@ -371,4 +370,5 @@ bool BootKeyboard_::wasAnyModifierActive() {
   return last_report_.modifiers > 0;
 }
 
+__attribute__((weak))
 BootKeyboard_ BootKeyboard;

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -45,7 +45,7 @@ typedef union {
 
 class BootKeyboard_ : public PluggableUSBModule {
  public:
-  BootKeyboard_();
+  BootKeyboard_(uint8_t protocol_ = HID_REPORT_PROTOCOL);
   size_t press(uint8_t k);
   void begin();
   void end();
@@ -65,7 +65,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   uint8_t getProtocol();
   void setProtocol(uint8_t protocol);
 
-  uint8_t default_protocol = HID_REPORT_PROTOCOL;
+  uint8_t default_protocol;
 
  protected:
   HID_BootKeyboardReport_Data_t report_, last_report_;


### PR DESCRIPTION
Instead of doing the plugging late, in `.begin()`, allow setting the protocol in the constructor, and mark the global object weak, so it can be overridden in a user sketch, with one that has the desired protocol set.

We originally moved the `PluggableUSB().plug(this)` call from the constructor to `.begin()` in 186c8b4538ee3fb8d014c7871ba12a1412b8c1dd, to make it possible to set the default protocol the boot keyboard boots up with. However, this never really worked reliably, and was a bit finicky.

By allowing to override the object, we can set the protocol more reliably.

As a side effect, by moving the plugging to the constructor, the library will also work better with the (currently work in progress) arduino core for GD32 - though that needs other changes on top of this.