### PR TITLE
Fix init order warning for BootKeyboard constructor

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -73,7 +73,7 @@ static const uint8_t boot_keyboard_hid_descriptor_[] PROGMEM = {
   D_END_COLLECTION
 };
 
-BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), protocol(protocol_), default_protocol(protocol_), idle(1), leds(0) {
+BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(1), leds(0) {
   epType[0] = EP_TYPE_INTERRUPT_IN;
   PluggableUSB().plug(this);
 }


### PR DESCRIPTION
The constructor for `BootKeyboard` had its member initialization list arguments (`protocol` and `default_protocol`) in the wrong order; they're required to be in the same order the member variables are declared in the class definition in the header file.  This was causing `-Wreorder` warnings, caused by #73.

The fix was very simple, and since it doesn't affect the parameters of the constructor, only the member initialization list, it's a very minimal change.