### PR TITLE
Simplify and correct Mouse features

### DIFF
--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -83,9 +83,19 @@ void Mouse_::end() {
 }
 
 void Mouse_::click(uint8_t b) {
+  // If one or more of the buttons to be clicked was already pressed, we need to
+  // send a report to release it first, to guarantee that this will be a "click"
+  // and not merely a release.
+  if (report_.buttons & b) {
+    release(b);
+    sendReport();
+  }
+  // Next, send a report with the button(s) pressed:
   press(b);
   sendReport();
+  // Finally, send the report with the button(s) released:
   release(b);
+  sendReport();
 }
 
 void Mouse_::move(int8_t x, int8_t y, int8_t v_wheel, int8_t h_wheel) {

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -118,20 +118,16 @@ void Mouse_::sendReportUnchecked() {
 }
 
 void Mouse_::sendReport() {
-  // If the last report is different than the current report, then we need to
-  // send a report.  We guard sendReport like this so that calling code doesn't
-  // end up spamming the host with empty reports if sendReport is called in a
-  // tight loop.
-
-  // if the two reports are the same, check if they're empty, and return early
-  // without a report if they are.
-  static HID_MouseReport_Data_t empty_report;
-  if (memcmp(&last_report_, &report_, sizeof(report_)) == 0 &&
-      memcmp(&report_, &empty_report, sizeof(report_)) == 0)
-    return;
-
-  sendReportUnchecked();
-  memcpy(&last_report_, &report_, sizeof(report_));
+  // If the button state has not changed, and neither the cursor nor the wheel
+  // is being told to move, there is no need to send a report.  This check
+  // prevents us from sending lots of no-op reports if the caller is in a loop
+  // and not checking or buggy.
+  if (report_.buttons != prev_report_buttons_ ||
+      report_.xAxis != 0 || report_.yAxis != 0 ||
+      report_.vWheel != 0 || report_.hWheel != 0) {
+    sendReportUnchecked();
+    prev_report_buttons_ = report_.buttons;
+  }
 }
 
 Mouse_ Mouse;

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -48,6 +48,9 @@ class Mouse_ {
   Mouse_();
   void begin();
   void end();
+  // Note: the following `click()` method is unlike the `move()`, `press()`, and
+  // `release()` methods, in that it doesn't merely modify the pending report,
+  // but also calls `sendReport()` at least twice.
   void click(uint8_t b = MOUSE_LEFT);
   void move(int8_t x, int8_t y, int8_t v_wheel = 0, int8_t h_wheel = 0);
   void press(uint8_t b = MOUSE_LEFT);   // press LEFT by default

--- a/src/MultiReport/Mouse.h
+++ b/src/MultiReport/Mouse.h
@@ -69,7 +69,7 @@ class Mouse_ {
 
  protected:
   HID_MouseReport_Data_t report_;
-  HID_MouseReport_Data_t last_report_;
+  uint8_t prev_report_buttons_ = 0;
 
  private:
   void sendReportUnchecked();


### PR DESCRIPTION
Two changes: a simplification and correction of the suppression of no-op mouse reports, and a correction of the `click()` method.

The logic for no-op report suppression had been incorrect, so we would sometimes send a report with the button state unchanged and all zeros for cursor and scroll movement.  This fixes that, and also makes the code clearer and streamlines things (there's no point in storing a full copy of the previous mouse report when the only thing that it's valid to compare against is the button state).

The `click()` method was built assuming that a report would be sent every cycle, so it didn't bother sending the second ("release") report explicitly.  This is not a safe assumption (current Kaleidoscope doesn't do this).  Also, if the button(s) in question were already held, they would need to be released first in order to make a "click".

Fixes #52 