### PR TITLE
Create unions for fields we receive from the host with backing buffers that are modulo 16 bits in size.

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -193,8 +193,8 @@ bool BootKeyboard_::setup(USBSetup& setup) {
       int length = setup.wLength;
 
       if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
-        if (length == sizeof(leds)) {
-          USB_RecvControl(&leds, length);
+        if (length == sizeof(leds_wrapper.leds)) {
+          USB_RecvControl(&leds_wrapper.leds, length);
           return true;
         }
       }

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -77,7 +77,19 @@ class BootKeyboard_ : public PluggableUSBModule {
   EPTYPE_DESCRIPTOR_SIZE epType[1];
   uint8_t protocol;
   uint8_t idle;
+  union {
+  	uint8_t leds;
+	uint8_t padding_[2];
+	} leds_wrapper;
+        /*
+         * Create union for the ‘leds’ field that has a backing
+         * buffers that is modulo 16 bits in size.
+         *
+         * This is currently necessary because on GD 32 this field is read
+         * directly from the USB peripheral with ‘usbd_ep_data_read’,
+         * which can only read in 16-bit chunks (as of version 2.1.2
+         * of the firmware library).
+         */
 
-  uint8_t leds;
 };
 extern BootKeyboard_ BootKeyboard;

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -160,8 +160,8 @@ bool HID_::setup(USBSetup& setup) {
 
       if (length == sizeof(setReportData)) {
         USB_RecvControl(&setReportData, length);
-      } else if (length == sizeof(setReportData.leds)) {
-        USB_RecvControl(&setReportData.leds, length);
+      } else if (length == sizeof(setReportData.leds_wrapper.leds)) {
+        USB_RecvControl(&setReportData.leds_wrapper.leds, length);
         setReportData.reportId = 0;
       }
     }
@@ -174,7 +174,7 @@ HID_::HID_() : PluggableUSBModule(1, 1, epType),
   rootNode(NULL), descriptorSize(0),
   protocol(HID_REPORT_PROTOCOL), idle(1) {
   setReportData.reportId = 0;
-  setReportData.leds = 0;
+  setReportData.leds_wrapper.leds = 0;
 
 #ifdef ARCH_HAS_CONFIGURABLE_EP_SIZES
   epType[0] = EP_TYPE_INTERRUPT_IN(USB_EP_SIZE);

--- a/src/HID.h
+++ b/src/HID.h
@@ -96,7 +96,7 @@ class HID_ : public PluggableUSBModule {
   int SendReport(uint8_t id, const void* data, int len);
   void AppendDescriptor(HIDSubDescriptor* node);
   uint8_t getLEDs() {
-    return setReportData.leds;
+    return setReportData.leds_wrapper.leds;
   };
 
  protected:
@@ -117,7 +117,13 @@ class HID_ : public PluggableUSBModule {
   uint8_t idle;
   struct {
     uint8_t reportId;
-    uint8_t leds;
+    /* this wrapper union is here because on GD32, the USB endpoint reading code *only* works with 
+     * chunks of data that are multiples of 16 bits
+     */
+    union {
+	    uint8_t leds;
+	    uint8_t padding_[2];
+    } leds_wrapper;
   } setReportData;
 };
 


### PR DESCRIPTION
buffers that are modulo 16 bits in size.

This is currently necessary because these fields are read
directly from the USB peripheral with ‘usbd_ep_data_read’,
which can only read in 16-bit chunks (as of version 2.1.2
of the firmware library).