### PR TITLE
Alternative workaround for the GD32 `void*` -> `uint16_t*` cast problem

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -192,12 +192,32 @@ bool BootKeyboard_::setup(USBSetup& setup) {
       // Check if data has the correct length afterwards
       int length = setup.wLength;
 
+      // ------------------------------------------------------------
+      // Workaround for a bug in the GD32 core:
+      //
+      // On GD32, when we call `USV_RecvControl`, it casts the (void*) pointer
+      // we give it to `uint16_t*`, which means that it will alway write an even
+      // number of bytes to that pointer.  Because we don't want to overwrite
+      // the next byte in memory past `leds`, we use a temporary array that is
+      // guaranteed to be big enough, and copy the data from that:
       if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
         if (length == sizeof(leds)) {
-          USB_RecvControl(&leds, length);
+          uint8_t raw_report_data[2];
+          USB_RecvControl(&raw_report_data, length);
+          leds = raw_report_data[0];
           return true;
         }
       }
+      // Once the GD32 core bug is fixed, we can replace the above code with the
+      // original code below:
+      // ------------------------------------------------------------
+      // if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
+      //   if (length == sizeof(leds)) {
+      //     USB_RecvControl(&leds, length);
+      //     return true;
+      //   }
+      // }
+      // ------------------------------------------------------------
 
       // Input (set HID report)
       else if (setup.wValueH == HID_REPORT_TYPE_INPUT) {

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -193,8 +193,8 @@ bool BootKeyboard_::setup(USBSetup& setup) {
       int length = setup.wLength;
 
       if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
-        if (length == sizeof(leds_wrapper.leds)) {
-          USB_RecvControl(&leds_wrapper.leds, length);
+        if (length == sizeof(leds)) {
+          USB_RecvControl(&leds, length);
           return true;
         }
       }

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -80,7 +80,7 @@ static const uint8_t BOOT_KEYBOARD_EP_SIZE = USB_EP_SIZE;
 #endif
 
 
-BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(1), leds_wrapper.leds(0) {
+BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(1), leds(0) {
 #ifdef ARCH_HAS_CONFIGURABLE_EP_SIZES
   epType[0] = EP_TYPE_INTERRUPT_IN(BOOT_KEYBOARD_EP_SIZE); // This is an 8 byte report, so ask for an 8 byte buffer, so reports aren't split
 #else
@@ -213,7 +213,7 @@ bool BootKeyboard_::setup(USBSetup& setup) {
 }
 
 uint8_t BootKeyboard_::getLeds() {
-  return leds_wrapper.leds;
+  return leds;
 }
 
 uint8_t BootKeyboard_::getProtocol() {

--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -80,7 +80,7 @@ static const uint8_t BOOT_KEYBOARD_EP_SIZE = USB_EP_SIZE;
 #endif
 
 
-BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(1), leds_wrapper({0}) {
+BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(1), leds_wrapper.leds(0) {
 #ifdef ARCH_HAS_CONFIGURABLE_EP_SIZES
   epType[0] = EP_TYPE_INTERRUPT_IN(BOOT_KEYBOARD_EP_SIZE); // This is an 8 byte report, so ask for an 8 byte buffer, so reports aren't split
 #else

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -77,19 +77,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   EPTYPE_DESCRIPTOR_SIZE epType[1];
   uint8_t protocol;
   uint8_t idle;
-  union {
-  	uint8_t leds;
-	uint8_t padding_[2];
-	} leds_wrapper;
-        /*
-         * Create union for the ‘leds’ field that has a backing
-         * buffers that is modulo 16 bits in size.
-         *
-         * This is currently necessary because on GD 32 this field is read
-         * directly from the USB peripheral with ‘usbd_ep_data_read’,
-         * which can only read in 16-bit chunks (as of version 2.1.2
-         * of the firmware library).
-         */
 
+  uint8_t leds;
 };
 extern BootKeyboard_ BootKeyboard;

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -160,8 +160,8 @@ bool HID_::setup(USBSetup& setup) {
 
       if (length == sizeof(setReportData)) {
         USB_RecvControl(&setReportData, length);
-      } else if (length == sizeof(setReportData.leds_wrapper.leds)) {
-        USB_RecvControl(&setReportData.leds_wrapper.leds, length);
+      } else if (length == sizeof(setReportData.leds)) {
+        USB_RecvControl(&setReportData.leds, length);
         setReportData.reportId = 0;
       }
     }
@@ -174,7 +174,7 @@ HID_::HID_() : PluggableUSBModule(1, 1, epType),
   rootNode(NULL), descriptorSize(0),
   protocol(HID_REPORT_PROTOCOL), idle(1) {
   setReportData.reportId = 0;
-  setReportData.leds_wrapper.leds = 0;
+  setReportData.leds = 0;
 
 #ifdef ARCH_HAS_CONFIGURABLE_EP_SIZES
   epType[0] = EP_TYPE_INTERRUPT_IN(USB_EP_SIZE);

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -158,12 +158,37 @@ bool HID_::setup(USBSetup& setup) {
     if (request == HID_SET_REPORT) {
       uint16_t length = setup.wLength;
 
+      // ------------------------------------------------------------
+      // Workaround for a bug in the GD32 core:
+      //
+      // On GD32, when we call `USV_RecvControl`, it casts the (void*) pointer
+      // we give it to `uint16_t*`, which means that it will alway write an even
+      // number of bytes to that pointer.  Because we might be trying to just
+      // read the `leds` byte, and we don't want to overwrite the next byte in
+      // memory, instead of giving it the pointer to the `setReportData` member
+      // variable directly, we have it write into to temporary `raw_report_data`
+      // array that's guaranteed to be big enough, then copy the data from that
+      // array into `setReportData`:
+      uint8_t raw_report_data[sizeof(setReportData) + 1];
       if (length == sizeof(setReportData)) {
-        USB_RecvControl(&setReportData, length);
+        USB_RecvControl(&raw_report_data, length);
+        setReportData.reportId = raw_report_data[0];
+        setReportData.leds = raw_report_data[1];
       } else if (length == sizeof(setReportData.leds)) {
-        USB_RecvControl(&setReportData.leds, length);
+        USB_RecvControl(&raw_report_data, length);
         setReportData.reportId = 0;
+        setReportData.leds = raw_report_data[0];
       }
+      // Once the GD32 core bug is fixed, we can replace the above code with the
+      // original code below:
+      // ------------------------------------------------------------
+      // if (length == sizeof(setReportData)) {
+      //   USB_RecvControl(&setReportData, length);
+      // } else if (length == sizeof(setReportData.leds)) {
+      //   USB_RecvControl(&setReportData.leds, length);
+      //   setReportData.reportId = 0;
+      // }
+      // ------------------------------------------------------------
     }
   }
 

--- a/src/HID.h
+++ b/src/HID.h
@@ -96,7 +96,7 @@ class HID_ : public PluggableUSBModule {
   int SendReport(uint8_t id, const void* data, int len);
   void AppendDescriptor(HIDSubDescriptor* node);
   uint8_t getLEDs() {
-    return setReportData.leds_wrapper.leds;
+    return setReportData.leds;
   };
 
  protected:
@@ -117,13 +117,7 @@ class HID_ : public PluggableUSBModule {
   uint8_t idle;
   struct {
     uint8_t reportId;
-    /* this wrapper union is here because on GD32, the USB endpoint reading code *only* works with 
-     * chunks of data that are multiples of 16 bits
-     */
-    union {
-	    uint8_t leds;
-	    uint8_t padding_[2];
-    } leds_wrapper;
+    uint8_t leds;
   } setReportData;
 };
 


### PR DESCRIPTION
This is an alternative to #83, with the code changes confined to the method implementations in the affected source files.  It has the benefit of not affecting the virtual HID code in Kaleidoscope, and I think it's much easier to follow than the `union` approach.