### PR TITLE
Don't send empty reports upon enumeration.

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -122,11 +122,6 @@ int BootKeyboard_::getDescriptor(USBSetup& setup) {
 
 
 void BootKeyboard_::begin() {
-  // Force API to send a clean report.
-  // This is important for and HID bridge where the receiver stays on,
-  // while the sender is resetted.
-  releaseAll();
-  sendReport();
 }
 
 

--- a/src/DeviceAPIs/AbsoluteMouseAPI.hpp
+++ b/src/DeviceAPIs/AbsoluteMouseAPI.hpp
@@ -54,8 +54,6 @@ int16_t AbsoluteMouseAPI::qadd16(int16_t base, int16_t increment) {
 }
 
 void AbsoluteMouseAPI::begin() {
-  // release all buttons
-  end();
 }
 
 void AbsoluteMouseAPI::end() {

--- a/src/MultiReport/ConsumerControl.cpp
+++ b/src/MultiReport/ConsumerControl.cpp
@@ -50,8 +50,6 @@ ConsumerControl_::ConsumerControl_() {
 }
 
 void ConsumerControl_::begin() {
-  // release all buttons
-  end();
 }
 
 void ConsumerControl_::end() {

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -81,8 +81,6 @@ Gamepad_::Gamepad_() {
 }
 
 void Gamepad_::begin() {
-  // release all buttons
-  end();
 }
 
 void Gamepad_::end() {

--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -82,10 +82,6 @@ Keyboard_::Keyboard_() {
 }
 
 void Keyboard_::begin() {
-  // Force API to send a clean report.  This is important for and HID bridge
-  // where the receiver stays on, while the sender is resetted.
-  releaseAll();
-  sendReportUnchecked();
 }
 
 

--- a/src/MultiReport/Mouse.cpp
+++ b/src/MultiReport/Mouse.cpp
@@ -74,7 +74,6 @@ Mouse_::Mouse_() {
 }
 
 void Mouse_::begin() {
-  end();
 }
 
 void Mouse_::end() {

--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -51,8 +51,6 @@ SystemControl_::SystemControl_() {
 }
 
 void SystemControl_::begin() {
-  // release all buttons
-  end();
 }
 
 void SystemControl_::end() {


### PR DESCRIPTION
We inherited code from Nico Hood's HID project that would always send a
"release" report at init time.  This is...not actually correct on a
normal device. This commit reverts that behavior, which, among other
things, caused the Keyboardio Model 100 to freeze on boot on Intel macs.

Tested on the Model 01 and the Model 100


That code came with this comment:
    // Force API to send a clean report.
    // This is important for and HID bridge where the receiver stays on,
    // while the sender is resetted.

Added in this commit:

  commit eff788e5405f47ce348c2f7cee2c47aab95c9efd
  Author: NicoHood <NicoHood@users.noreply.github.com>
  Date:   Sun Oct 25 14:26:55 2015 +0100

      Made Keyboard API a lot more flexible