### PR TITLE
SystemControl: Call the right function in release() and releaseAll()

### DIFF
--- a/src/MultiReport/SystemControl.cpp
+++ b/src/MultiReport/SystemControl.cpp
@@ -54,8 +54,7 @@ void SystemControl_::begin() {
 }
 
 void SystemControl_::end() {
-  uint8_t report = 0x00;
-  sendReport(&report, sizeof(report));
+  releaseAll();
 }
 
 void SystemControl_::write(uint8_t s) {
@@ -64,11 +63,12 @@ void SystemControl_::write(uint8_t s) {
 }
 
 void SystemControl_::release() {
-  begin();
+  releaseAll();
 }
 
 void SystemControl_::releaseAll() {
-  begin();
+  uint8_t report = 0x00;
+  sendReport(&report, sizeof(report));
 }
 
 void SystemControl_::press(uint8_t s) {


### PR DESCRIPTION
Since ab9702352f09f4f4ceee0ba639f872d00df06e93,  `SystemControl_::begin()` is a no-op, calling it in `release()` and `releaseAll()` is not doing what it did prior to that commit: call `end()`, which is what the release functions really wanted to do in the first place.

Lets do the right thing then, and call `end()`.
