### PR TITLE
fix NKRO report fencepost

### DIFF
--- a/src/MultiReport/Keyboard.cpp
+++ b/src/MultiReport/Keyboard.cpp
@@ -64,13 +64,15 @@ static const uint8_t nkro_keyboard_hid_descriptor_[] PROGMEM = {
   D_LOGICAL_MINIMUM, 0x00,
   D_LOGICAL_MAXIMUM, 0x01,
   D_REPORT_SIZE, 0x01,
-  D_REPORT_COUNT, (HID_LAST_KEY - HID_KEYBOARD_A_AND_A),
+  D_REPORT_COUNT, (KEY_BITS - 4),
   D_INPUT, (D_DATA | D_VARIABLE | D_ABSOLUTE),
 
-  // Padding (3 bits) to round up the report to byte boundary.
-  D_REPORT_SIZE, 0x03,
+#if (KEY_BITS % 8)
+  // Padding to round up the report to byte boundary.
+  D_REPORT_SIZE, (8 - (KEY_BITS % 8)),
   D_REPORT_COUNT, 0x01,
   D_INPUT, (D_CONSTANT),
+#endif
 
   D_END_COLLECTION,
 };

--- a/src/MultiReport/Keyboard.h
+++ b/src/MultiReport/Keyboard.h
@@ -33,7 +33,8 @@ THE SOFTWARE.
 #include "HIDTables.h"
 #include "HIDAliases.h"
 
-#define KEY_BYTES 28
+#define KEY_BITS (4 + HID_LAST_KEY - HID_KEYBOARD_A_AND_A + 1)
+#define KEY_BYTES ((KEY_BITS + 7) / 8)
 
 typedef union {
   // Modifiers + keymap


### PR DESCRIPTION
There was a fencepost error in counting the number of bits in the key bitmap. This resulted in the report descriptor declaring one more Usage than items in the report, which might cause validation problems on some HID implementations.

The only affected Usage was Keypad Hexadecimal, which is probably not used often.
