### PR TITLE
fix get/set idle

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -80,7 +80,7 @@ static const uint8_t BOOT_KEYBOARD_EP_SIZE = USB_EP_SIZE;
 #endif
 
 
-BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(1), leds(0) {
+BootKeyboard_::BootKeyboard_(uint8_t protocol_) : PluggableUSBModule(1, 1, epType), default_protocol(protocol_), protocol(protocol_), idle(0), leds(0) {
 #ifdef ARCH_HAS_CONFIGURABLE_EP_SIZES
   epType[0] = EP_TYPE_INTERRUPT_IN(BOOT_KEYBOARD_EP_SIZE); // This is an 8 byte report, so ask for an 8 byte buffer, so reports aren't split
 #else
@@ -175,14 +175,7 @@ bool BootKeyboard_::setup(USBSetup& setup) {
       return true;
     }
     if (request == HID_SET_IDLE) {
-      // We currently ignore SET_IDLE, because we don't really do anything with it, and implementing
-      // it causes issues on OSX, such as key chatter. Other operating systems do not suffer if we
-      // force this to zero, either.
-#if 0
       idle = setup.wValueL;
-#else
-      idle = 0;
-#endif
       return true;
     }
     if (request == HID_SET_REPORT) {

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -140,7 +140,8 @@ bool HID_::setup(USBSetup& setup) {
       return true;
     }
     if (request == HID_GET_IDLE) {
-      // TODO: Send8(idle);
+      USB_SendControl(TRANSFER_RELEASE, &idle, sizeof(idle));
+      return true;
     }
   }
 
@@ -198,7 +199,7 @@ bool HID_::setup(USBSetup& setup) {
 
 HID_::HID_() : PluggableUSBModule(1, 1, epType),
   rootNode(NULL), descriptorSize(0),
-  protocol(HID_REPORT_PROTOCOL), idle(1) {
+  protocol(HID_REPORT_PROTOCOL), idle(0) {
   setReportData.reportId = 0;
   setReportData.leds = 0;
 


### PR DESCRIPTION
Always respond with the current Idle period, possibly set by the host. Also, set the initial idle period to 0 (indefinite), because that's how we actually behave.
