### PR TITLE
reset protocol on bus reset

### DIFF
--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -65,6 +65,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   void setProtocol(uint8_t protocol);
 
   uint8_t default_protocol;
+  void checkReset();
 
  protected:
   HID_BootKeyboardReport_Data_t report_, last_report_;

--- a/src/HID-Settings.h
+++ b/src/HID-Settings.h
@@ -81,6 +81,7 @@ void USB_PackMessages(bool pack);
 #include <PluggableUSB.h>
 
 #define EPTYPE_DESCRIPTOR_SIZE      uint8_t
+#define USB_Configured              USBDevice.configured
 
 #elif defined(ARDUINO_ARCH_SAM)
 
@@ -104,6 +105,7 @@ void USB_PackMessages(bool pack);
 #define USB_Recv                    USBD_Recv
 #define USB_Send                    USBD_Send
 #define USB_Flush                   USBD_Flush
+#define USB_Configured              USBDevice.configured
 
 #elif defined(ARDUINO_ARCH_SAMD)
 
@@ -119,6 +121,7 @@ void USB_PackMessages(bool pack);
 #define USB_RecvControl             USBDevice.recvControl
 #define USB_Send                    USBDevice.send
 #define USB_Flush                   USBDevice.flush
+#define USB_Configured              USBDevice.configured
 
 int USB_SendControl(void* y, uint8_t z);
 int USB_SendControl(uint8_t x, const void* y, uint8_t z);
@@ -143,7 +146,7 @@ int USB_SendControl(uint8_t x, const void* y, uint8_t z);
 constexpr uint16_t EP_TYPE_INTERRUPT_IN(uint8_t buffer_size) { return EPDesc(USB_TRX_IN, USB_EP_ATTR_INT, buffer_size).val; }
 constexpr uint16_t EP_TYPE_INTERRUPT_OUT(uint8_t buffer_size) { return EPDesc(USB_TRX_OUT, USB_EP_ATTR_INT, buffer_size).val; }
 
-
+#define USB_Configured USBCore().configured
 
 #else
 

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -62,10 +62,6 @@ int HID_::getDescriptor(USBSetup& setup) {
     total += res;
   }
 
-  // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-  // due to the USB specs, but Windows and Linux just assumes its in report mode.
-  protocol = HID_REPORT_PROTOCOL;
-
   USB_PackMessages(false);
   return total;
 }

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -81,10 +81,6 @@ int SingleAbsoluteMouse_::getDescriptor(USBSetup& setup) {
     return 0;
   }
 
-  // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-  // due to the USB specs, but Windows and Linux just assumes its in report mode.
-  protocol = HID_REPORT_PROTOCOL;
-
   return USB_SendControl(TRANSFER_PGM, _hidSingleReportDescriptorAbsoluteMouse, sizeof(_hidSingleReportDescriptorAbsoluteMouse));
 }
 
@@ -102,15 +98,13 @@ bool SingleAbsoluteMouse_::setup(USBSetup& setup) {
       return true;
     }
     if (request == HID_GET_PROTOCOL) {
-      // TODO: Send8(protocol);
-      return true;
+      return false;
     }
   }
 
   if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE) {
     if (request == HID_SET_PROTOCOL) {
-      protocol = setup.wValueL;
-      return true;
+      return false;
     }
     if (request == HID_SET_IDLE) {
       idle = setup.wValueL;


### PR DESCRIPTION
Only reset boot/report protocol on USB bus reset. Windows 10 will sometimes try to cache report descriptors if it has high confidence that it's a device it's seen before. This means it won't retrieve either the configuration descriptor set or the report descriptors when resetting after receving control from the BIOS/UEFI. The BIOS or UEFI probably set the boot keyboard to boot protocol, which meant that when Windows regained control, the boot keyboard was still in boot protocol, contrary to the USB HID specification.

This requires the higher-level driver to call a polling function, because detection of USB reset events isn't as portable as checking the USB device configuration.