### PR TITLE
make BootKeyboard first HID

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -415,4 +415,7 @@ void BootKeyboard_::checkReset() {
 }
 
 __attribute__((weak))
-BootKeyboard_ BootKeyboard;
+BootKeyboard_& BootKeyboard() {
+  static BootKeyboard_ obj;
+  return obj;
+};

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -81,4 +81,4 @@ class BootKeyboard_ : public PluggableUSBModule {
 
   uint8_t leds;
 };
-extern BootKeyboard_ BootKeyboard;
+extern BootKeyboard_& BootKeyboard();

--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -20,6 +20,7 @@
 
 #include "HID.h"
 #include "HIDReportObserver.h"
+#include "BootKeyboard/BootKeyboard.h"
 
 #if defined(USBCON)
 
@@ -192,6 +193,9 @@ bool HID_::setup(USBSetup& setup) {
 HID_::HID_() : PluggableUSBModule(1, 1, epType),
   rootNode(NULL), descriptorSize(0),
   protocol(HID_REPORT_PROTOCOL), idle(0) {
+  // Invoke BootKeyboard constructor so it will be the first HID interface
+  (void)BootKeyboard();
+
   setReportData.reportId = 0;
   setReportData.leds = 0;
 

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 */
 
 #include "SingleAbsoluteMouse.h"
+#include "BootKeyboard/BootKeyboard.h"
 #include "HIDReportObserver.h"
 #include "HID-Settings.h"
 
@@ -48,6 +49,8 @@ static const uint8_t SINGLE_ABSOLUTEMOUSE_EP_SIZE = USB_EP_SIZE;
 
 SingleAbsoluteMouse_::SingleAbsoluteMouse_() : PluggableUSBModule(1, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1) {
 
+  // Invoke BootKeyboard constructor so it will be the first HID interface
+  (void)BootKeyboard();
 #ifdef ARCH_HAS_CONFIGURABLE_EP_SIZES
   epType[0] = EP_TYPE_INTERRUPT_IN(SINGLE_ABSOLUTEMOUSE_EP_SIZE);
 #else


### PR DESCRIPTION
Use a singleton for BootKeyboard to make sure that it is the first HID interface. Some UEFIs or BIOSes appear to only recognize a boot keyboard if it's the first HID interface.
