### PR TITLE
use an action hook onReset for BootKeyboard

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -394,24 +394,13 @@ bool BootKeyboard_::wasAnyModifierActive() {
 }
 
 /*
- * Check whether the device has seen a bus reset. Unfortunately, the most
- * portable way is to poll for changes in the host-selected configuration. This
- * needs to be periodically called from the keyboard driver to poll for a reset
- * condition.
+ * Hook function to reset any needed state after a USB reset.
+ *
+ * Right now, it sets the protocol back to the default (report protocol), as
+ * required by the HID specification.
  */
-void BootKeyboard_::checkReset() {
-  static bool was_configed;
-
-  if (was_configed) {
-    if (!USB_Configured()) {
-      was_configed = false;
-      protocol = default_protocol;
-    }
-  } else {
-    if (USB_Configured()) {
-      was_configed = true;
-    }
-  }
+void BootKeyboard_::onUSBReset() {
+  protocol = default_protocol;
 }
 
 __attribute__((weak))

--- a/src/BootKeyboard/BootKeyboard.h
+++ b/src/BootKeyboard/BootKeyboard.h
@@ -65,7 +65,7 @@ class BootKeyboard_ : public PluggableUSBModule {
   void setProtocol(uint8_t protocol);
 
   uint8_t default_protocol;
-  void checkReset();
+  void onUSBReset();
 
  protected:
   HID_BootKeyboardReport_Data_t report_, last_report_;


### PR DESCRIPTION
Instead of having a poll function to check for USB reset in BootKeyboard, use an onReset hook instead.

This should also fix the simulator build failures, which were due to a lack of mocking of `USBDevice` in the virtual hardware.