### PR TITLE
remove GD32 `recvControl` workaround

### DIFF
--- a/src/BootKeyboard/BootKeyboard.cpp
+++ b/src/BootKeyboard/BootKeyboard.cpp
@@ -179,37 +179,12 @@ bool BootKeyboard_::setup(USBSetup& setup) {
       // Check if data has the correct length afterwards
       int length = setup.wLength;
       
-
-      // ------------------------------------------------------------
-      // Workaround for a bug in the GD32 core:
-      //
-      // On GD32, when we call `USV_RecvControl`, it casts the (void*) pointer
-      // we give it to `uint16_t*`, which means that it will alway write an even
-      // number of bytes to that pointer.  Because we don't want to overwrite
-      // the next byte in memory past `leds`, we use a temporary array that is
-      // guaranteed to be big enough, and copy the data from that:
       if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
         if (length == sizeof(leds)) {
-          uint8_t raw_report_data[2];
-          USB_RecvControl(&raw_report_data, length);
-          leds = raw_report_data[0];
+          USB_RecvControl(&leds, length);
           return true;
-//        } else {
-//	  char tmp[8];
-//	  USB_RecvControl(&tmp, length);
-//	  return true;
-	}	
+        }
       }
-      // Once the GD32 core bug is fixed, we can replace the above code with the
-      // original code below:
-      // ------------------------------------------------------------
-      // if (setup.wValueH == HID_REPORT_TYPE_OUTPUT) {
-      //   if (length == sizeof(leds)) {
-      //     USB_RecvControl(&leds, length);
-      //     return true;
-      //   }
-      // }
-      // ------------------------------------------------------------
 
       // Input (set HID report)
       else if (setup.wValueH == HID_REPORT_TYPE_INPUT) {


### PR DESCRIPTION
Remove the GD32 `recvControl` workaround, because changes to the USB core mean that it's no longer required.